### PR TITLE
Fix env var usage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func init() {
 
 	flags.Int32("organization", 0, "organization id")
 	_ = viper.BindPFlag("organization.id", flags.Lookup("organization"))
+	viper.BindEnv("organization.id", "BANZAI_CURRENT_ORG_ID")
 
 	flags.Bool("no-color", false, "never display color output")
 	_ = viper.BindPFlag("formatting.no-color", flags.Lookup("no-color"))
@@ -117,8 +118,6 @@ func initConfig() {
 		viper.AddConfigPath(path.Join(home, ".banzai"))
 		viper.SetConfigName("config")
 	}
-
-	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/internal/cli/command/cluster/legacy.go
+++ b/internal/cli/command/cluster/legacy.go
@@ -279,5 +279,6 @@ func GetClusterId(org int32, ask bool) int32 {
 func init() {
 	clusterShellCmd.PersistentFlags().Int32("cluster", 0, "cluster id")
 	viper.BindPFlag(clusterIdKey, clusterShellCmd.PersistentFlags().Lookup("cluster"))
+	viper.BindEnv(clusterIdKey, "BANZAI_CURRENT_CLUSTER_ID")
 	clusterShellCmd.PersistentFlags().StringVar(&clusterOptions.Name, "cluster-name", "", "cluster name")
 }


### PR DESCRIPTION
use env vars from #49  for selecting org/cluster in banzai-cli itself, and start cluster shell even if config is not yet available