### PR TITLE
cp: rewrite input file handling

### DIFF
--- a/cmd/banzai/main.go
+++ b/cmd/banzai/main.go
@@ -19,9 +19,9 @@ import "github.com/banzaicloud/banzai-cli/cmd"
 // Provisioned by ldflags
 // nolint: gochecknoglobals
 var (
-	version    string
-	commitHash string
-	buildDate  string
+	version         string
+	commitHash      string
+	buildDate       string
 	pipelineVersion string
 )
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,12 +15,13 @@
 package cli
 
 import (
-	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"sync"
+
+	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 
 	"github.com/goph/emperror"
 	"github.com/mattn/go-isatty"

--- a/internal/cli/command/controlplane/utils.go
+++ b/internal/cli/command/controlplane/utils.go
@@ -17,10 +17,16 @@ package controlplane
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 	"github.com/goph/emperror"
+	log "github.com/sirupsen/logrus"
 )
+
+const valuesDefault = "values.yaml"
 
 func unmarshal(raw []byte, data interface{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
@@ -33,13 +39,44 @@ func unmarshal(raw []byte, data interface{}) error {
 	// use this method to prevent unmarshalling directly with yaml, for example to map[interface{}]interface{}
 	converted, err := yaml.YAMLToJSON(raw)
 	if err != nil {
-		return emperror.Wrap(err, "unmarshal")
+		return emperror.Wrap(err, "unmarshal YAML")
 	}
 
 	decoder = json.NewDecoder(bytes.NewReader(converted))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(data); err != nil {
-		return emperror.Wrap(err, "unmarshal")
+		return emperror.Wrap(err, "unmarshal JSON")
+	}
+
+	return nil
+}
+
+// copyKubeconfig copies current Kubeconfig to the named file to a place where it is more likely that it can be mounted to DfM
+func copyKubeconfig(kubeconfigName string) error {
+	kubeconfigSource := os.Getenv("KUBECONFIG")
+	if kubeconfigSource == "" {
+		kubeconfigSource = os.Getenv("HOME") + "/.kube/config"
+	}
+
+	kubeconfigContent, err := ioutil.ReadFile(kubeconfigSource)
+	if err != nil {
+		return emperror.With(emperror.Wrapf(err, "failed to read kubeconfig %q", kubeconfigSource), "path", kubeconfigSource)
+	}
+
+	config := map[string]interface{}{}
+	if err := unmarshal(kubeconfigContent, &config); err != nil {
+		return emperror.Wrapf(err, "failed to parse kubeconfig %q", kubeconfigSource)
+	}
+
+	currentContext := config["current-context"]
+	if currentContext == nil {
+		return errors.New("can't find current context in kubeconfig")
+	}
+
+	log.Infof("Current Kubernetes context: %s", currentContext)
+
+	if err := ioutil.WriteFile(kubeconfigName, kubeconfigContent, 0600); err != nil {
+		return emperror.With(emperror.Wrapf(err, "failed to write temporary file %q", kubeconfigName), "path", kubeconfigName)
 	}
 
 	return nil

--- a/internal/cli/command/login.go
+++ b/internal/cli/command/login.go
@@ -17,6 +17,7 @@ package command
 import (
 	"errors"
 	"fmt"
+
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	"github.com/banzaicloud/banzai-cli/internal/cli/input"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
* copy kubeconfig to working dir temporarily (because /tmp is out of DfM default
shared paths)
* don't offer editing of values file during `cp down`
* fix input values editing during `cp up`