### PR TITLE
Fix docker for mac detection

### DIFF
--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -191,7 +191,7 @@ func isInteractive() bool {
 
 func runInternal(command, valuesFile, kubeconfigFile, tfdir string) error {
 
-	infoCmd := exec.Command("docker", "info", "-f", "{{eq .OperatingSystem \"Docker Desktop\"}}")
+	infoCmd := exec.Command("docker", "info", "-f", "{{or (eq .OperatingSystem \"Docker Desktop\") (eq .OperatingSystem \"Docker for Mac\")}}")
 
 	infoOuput, err := infoCmd.Output()
 	if err != nil {


### PR DESCRIPTION
On Edge it is called: `Docker Desktop`
On Stable it is: `Docker for Mac`