### PR TITLE
Add secret create command

### DIFF
--- a/cmd/docs/banzai_secret.md
+++ b/cmd/docs/banzai_secret.md
@@ -28,6 +28,7 @@ Manage secrets
 ### SEE ALSO
 
 * [banzai](banzai.md)	 - A command line client for the Banzai Cloud Pipeline platform.
+* [banzai secret create](banzai_secret_create.md)	 - Create secret
 * [banzai secret delete](banzai_secret_delete.md)	 - Delete one or more secrets
 * [banzai secret get](banzai_secret_get.md)	 - Get a secret
 * [banzai secret list](banzai_secret_list.md)	 - List secrets

--- a/cmd/docs/banzai_secret_create.md
+++ b/cmd/docs/banzai_secret_create.md
@@ -1,0 +1,64 @@
+## banzai secret create
+
+Create secret
+
+### Synopsis
+
+Create secret
+
+```
+banzai secret create [flags]
+```
+
+### Examples
+
+```
+
+	Create secret
+	---
+	$ banzai secret create
+	? Secret name mysecretname
+	? Choose secret type: password
+	? Set 'username' field: myusername
+	? Set 'password' field: mypassword
+	? Do you want to add tag(s) to this secret? Yes
+	? Tag: tag1
+	? Tag: tag2
+	? Tag: skip
+
+	Create secret with flags
+	---
+	$ banzai secret create --name mysecretname --type password --tags=cli
+	? Set 'username' field: myusername
+	? Set 'password' field: mypassword
+		
+```
+
+### Options
+
+```
+  -f, --file string        Secret creation descriptor file
+  -h, --help               help for create
+  -n, --name string        Name of the secret
+      --tags stringArray   Tags to add to the secret
+  -t, --type string        Type of the secret
+  -v, --validate string    Secret validation (true|false)
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai secret](banzai_secret.md)	 - Manage secrets
+

--- a/cmd/docs/banzai_secret_create.md
+++ b/cmd/docs/banzai_secret_create.md
@@ -4,7 +4,7 @@ Create secret
 
 ### Synopsis
 
-Create secret
+Create a secret in Pipeline's secret store interactively, or based on a json request from stdin or a file
 
 ```
 banzai secret create [flags]
@@ -28,21 +28,35 @@ banzai secret create [flags]
 
 	Create secret with flags
 	---
-	$ banzai secret create --name mysecretname --type password --tags=cli
+	$ banzai secret create --name mysecretname --type password --tag=cli --tag=my-application
 	? Set 'username' field: myusername
 	? Set 'password' field: mypassword
+
+	Create secret via json
+	---
+	$ banzai secret create <<EOF
+	> {
+	>	"name": "mysecretname",
+	>	"type": "password",
+	>	"values": {
+	>		"username": "myusername",
+	>		"password": "mypassword"
+	>	},
+	>	"tags":[ "cli", "my-application" ]
+	> }
+	> EOF
 		
 ```
 
 ### Options
 
 ```
-  -f, --file string        Secret creation descriptor file
-  -h, --help               help for create
-  -n, --name string        Name of the secret
-      --tags stringArray   Tags to add to the secret
-  -t, --type string        Type of the secret
-  -v, --validate string    Secret validation (true|false)
+  -f, --file string       Secret creation descriptor file
+  -h, --help              help for create
+  -n, --name string       Name of the secret
+      --tag stringArray   Tags to add to the secret
+  -t, --type string       Type of the secret
+  -v, --validate string   Secret validation (true|false)
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/command/cluster/create.go
+++ b/internal/cli/command/cluster/create.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	"github.com/banzaicloud/banzai-cli/internal/cli/input"
+	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -97,7 +98,7 @@ func runCreate(banzaiCli cli.Cli, options createOptions) error {
 			return emperror.Wrap(err, "failed to parse create cluster request")
 		}
 
-		if err := unmarshal(raw, &out); err != nil {
+		if err := utils.Unmarshal(raw, &out); err != nil {
 			return emperror.Wrap(err, "failed to unmarshal create cluster request")
 		}
 	}
@@ -187,7 +188,7 @@ func buildInteractiveCreateRequest(banzaiCli cli.Cli, options createOptions, org
 
 			continue
 		} else {
-			if err := unmarshal(raw, &out); err != nil {
+			if err := utils.Unmarshal(raw, &out); err != nil {
 				return emperror.Wrap(err, "failed to parse CreateClusterRequest")
 			}
 
@@ -376,7 +377,7 @@ func buildDefaultRequest(out map[string]interface{}) error {
 			return emperror.Wrap(err, "failed to marshal request template")
 		}
 
-		unmarshal(marshalled, &out)
+		utils.Unmarshal(marshalled, &out)
 	}
 	return nil
 }

--- a/internal/cli/command/cluster/install_secret.go
+++ b/internal/cli/command/cluster/install_secret.go
@@ -26,6 +26,7 @@ import (
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	"github.com/banzaicloud/banzai-cli/internal/cli/input"
+	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -95,7 +96,7 @@ func runInstallSecret(banzaiCli cli.Cli, options installSecretOptions) error {
 			return emperror.Wrap(err, "failed to parse create cluster request")
 		}
 
-		if err := unmarshal(raw, &out); err != nil {
+		if err := utils.Unmarshal(raw, &out); err != nil {
 			return emperror.Wrap(err, "failed to unmarshal create cluster request")
 		}
 
@@ -169,7 +170,7 @@ func buildInteractiveInstallSecretRequest(options installSecretOptions, out *pip
 
 			continue
 		} else {
-			if err := unmarshal(raw, &out); err != nil {
+			if err := utils.Unmarshal(raw, &out); err != nil {
 				return emperror.Wrap(err, "failed to parse InstallSecretRequest")
 			}
 

--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/goph/emperror"
 	"github.com/mattn/go-isatty"
 	log "github.com/sirupsen/logrus"
@@ -90,7 +91,7 @@ func runUp(options createOptions) error {
 
 				continue
 			} else {
-				if err := unmarshal(raw, &out); err != nil {
+				if err := utils.Unmarshal(raw, &out); err != nil {
 					return emperror.Wrap(err, "failed to parse control plane descriptor")
 				}
 
@@ -133,7 +134,7 @@ func runUp(options createOptions) error {
 			return emperror.Wrapf(err, "failed to read %q", filename)
 		}
 
-		if err := unmarshal(raw, &out); err != nil {
+		if err := utils.Unmarshal(raw, &out); err != nil {
 			return emperror.Wrap(err, "failed to parse controlplane descriptor")
 		}
 	}

--- a/internal/cli/command/controlplane/utils.go
+++ b/internal/cli/command/controlplane/utils.go
@@ -15,41 +15,16 @@
 package controlplane
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
 
-	"github.com/ghodss/yaml"
+	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/goph/emperror"
 	log "github.com/sirupsen/logrus"
 )
 
 const valuesDefault = "values.yaml"
-
-func unmarshal(raw []byte, data interface{}) error {
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(data); err == nil {
-		return nil
-	}
-
-	// if can't decode as json, try to convert it from yaml first
-	// use this method to prevent unmarshalling directly with yaml, for example to map[interface{}]interface{}
-	converted, err := yaml.YAMLToJSON(raw)
-	if err != nil {
-		return emperror.Wrap(err, "unmarshal YAML")
-	}
-
-	decoder = json.NewDecoder(bytes.NewReader(converted))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(data); err != nil {
-		return emperror.Wrap(err, "unmarshal JSON")
-	}
-
-	return nil
-}
 
 // copyKubeconfig copies current Kubeconfig to the named file to a place where it is more likely that it can be mounted to DfM
 func copyKubeconfig(kubeconfigName string) error {
@@ -64,7 +39,7 @@ func copyKubeconfig(kubeconfigName string) error {
 	}
 
 	config := map[string]interface{}{}
-	if err := unmarshal(kubeconfigContent, &config); err != nil {
+	if err := utils.Unmarshal(kubeconfigContent, &config); err != nil {
 		return emperror.Wrapf(err, "failed to parse kubeconfig %q", kubeconfigSource)
 	}
 

--- a/internal/cli/command/secret/cmd.go
+++ b/internal/cli/command/secret/cmd.go
@@ -31,6 +31,7 @@ func NewSecretCommand(banzaiCli cli.Cli) *cobra.Command {
 		NewListCommand(banzaiCli),
 		NewGetCommand(banzaiCli),
 		NewDeleteCommand(banzaiCli),
+		NewCreateCommand(banzaiCli),
 	)
 
 	return cmd

--- a/internal/cli/command/secret/create.go
+++ b/internal/cli/command/secret/create.go
@@ -234,6 +234,7 @@ func buildInteractiveCreateSecretRequest(banzaiCli cli.Cli, options createSecret
 			// request validation just in case of cloud types
 			prompt := &survey.Confirm{
 				Message: "Do you want to validate this secret?",
+				Default: true,
 			}
 			_ = survey.AskOne(prompt, &options.validate, nil)
 		}

--- a/internal/cli/command/secret/create.go
+++ b/internal/cli/command/secret/create.go
@@ -1,0 +1,409 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/antihax/optional"
+	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
+	"github.com/banzaicloud/banzai-cli/internal/cli"
+	"github.com/banzaicloud/banzai-cli/internal/cli/input"
+	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
+	"github.com/goph/emperror"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1"
+)
+
+const (
+	TypeGeneric = "generic"
+	TypeAmazon  = "amazon"
+	TypeAzure   = "azure"
+	TypeAlibaba = "alibaba"
+	TypeGoogle  = "google"
+	TypeOracle  = "oracle"
+)
+
+// createSecretOptions contains create secret flags for `banzai create secret` command
+type createSecretOptions struct {
+	file       string
+	secretName string
+	secretType string
+	tags       []string
+	validate   string
+}
+
+// secretFieldQuestion contains all necessary field for a secret question (any type except generic)
+type secretFieldQuestion struct {
+	input     *survey.Input
+	name      string
+	output    string
+	validator survey.Validator
+}
+
+// NewCreateCommand returns a cobra command for `banzai create create` command
+func NewCreateCommand(banzaiCli cli.Cli) *cobra.Command {
+	options := createSecretOptions{}
+
+	cmd := &cobra.Command{
+		Example: `
+	Create secret
+	---
+	$ banzai secret create
+	? Secret name mysecretname
+	? Choose secret type: password
+	? Set 'username' field: myusername
+	? Set 'password' field: mypassword
+	? Do you want to add tag(s) to this secret? Yes
+	? Tag: tag1
+	? Tag: tag2
+	? Tag: skip
+
+	Create secret with flags
+	---
+	$ banzai secret create --name mysecretname --type password --tags=cli
+	? Set 'username' field: myusername
+	? Set 'password' field: mypassword
+		`,
+		Use:     "create",
+		Aliases: []string{"c"},
+		Short:   "Create secret",
+		Long:    "Create secret",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreateSecret(banzaiCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVarP(&options.file, "file", "f", "", "Secret creation descriptor file")
+	flags.StringVarP(&options.secretName, "name", "n", "", "Name of the secret")
+	flags.StringVarP(&options.secretType, "type", "t", "", "Type of the secret")
+	flags.StringArrayVarP(&options.tags, "tags", "", []string{}, "Tags to add to the secret")
+	flags.StringVarP(&options.validate, "validate", "v", "", "Secret validation (true|false)")
+
+	return cmd
+}
+
+// runCreateSecret starts to get secret properties from the user via file or survey
+func runCreateSecret(banzaiCli cli.Cli, options createSecretOptions) error {
+	out := &pipeline.CreateSecretRequest{}
+
+	if err := getCreateSecretRequest(banzaiCli, options, out); err != nil {
+		return err
+	}
+
+	log.Debugf("create secret request: %#v", out)
+
+	orgID := input.GetOrganization(banzaiCli)
+	response, _, err := banzaiCli.Client().SecretsApi.AddSecrets(
+		context.Background(),
+		orgID,
+		*out,
+		&pipeline.AddSecretsOpts{
+			Validate: getValidationFlag(options.validate),
+		},
+	)
+	if err != nil {
+		cli.LogAPIError("create secret", err, out)
+		return emperror.Wrap(err, "failed to create secret")
+	}
+
+	log.Infof("Secret (%s) created with ID: %s", out.Name, response.Id)
+
+	return nil
+}
+
+func getCreateSecretRequest(banzaiCli cli.Cli, options createSecretOptions, out *pipeline.CreateSecretRequest) error {
+	if banzaiCli.Interactive() {
+		return buildInteractiveCreateSecretRequest(banzaiCli, options, out)
+	} else {
+		return readFileAndValidate(options.file, out)
+	}
+}
+
+func readFileAndValidate(filename string, out *pipeline.CreateSecretRequest) error {
+	var raw []byte
+	var err error
+
+	if filename != "" && filename != "-" {
+		raw, err = ioutil.ReadFile(filename)
+	} else {
+		raw, err = ioutil.ReadAll(os.Stdin)
+		filename = "stdin"
+	}
+
+	if err != nil {
+		return emperror.WrapWith(err, fmt.Sprintf("failed to read %q", filename), "filename", filename)
+	}
+
+	if err := validateCreateSecretRequest(raw); err != nil {
+		return emperror.Wrap(err, "failed to parse create cluster request")
+	}
+
+	if err := utils.Unmarshal(raw, &out); err != nil {
+		return emperror.Wrap(err, "failed to unmarshal create cluster request")
+	}
+
+	return nil
+}
+
+func validateCreateSecretRequest(val interface{}) error {
+	str, ok := val.(string)
+	if !ok {
+		if bytes, ok := val.([]byte); ok {
+			str = string(bytes)
+		} else {
+			return errors.New("value is not a string or []byte")
+		}
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(str))
+
+	var typer struct{ Type string }
+	err := decoder.Decode(&typer)
+	if err != nil {
+		return emperror.Wrap(err, "invalid JSON request")
+	}
+
+	decoder = json.NewDecoder(strings.NewReader(str))
+	decoder.DisallowUnknownFields()
+
+	return emperror.Wrap(decoder.Decode(&pipeline.CreateSecretRequest{}), "invalid request")
+}
+
+func buildInteractiveCreateSecretRequest(banzaiCli cli.Cli, options createSecretOptions, out *pipeline.CreateSecretRequest) error {
+
+	if len(options.file) != 0 {
+		if err := readCreateSecretRequestFromFile(options.file, out); err != nil {
+			// failed to load file, we can ask the user via survey
+			cli.LogAPIError("create secret", err, out)
+		} else {
+			options.secretType = out.Type
+			options.secretName = out.Name
+			return nil
+		}
+	}
+
+	allowedTypes, _, err := banzaiCli.Client().SecretsApi.AllowedSecretsTypes(context.Background())
+	if err != nil {
+		cli.LogAPIError("could not list secret types", err, nil)
+		log.Fatalf("could not list secret types: %v", err)
+	}
+
+	surveySecretName(&options)
+
+	surveySecretType(&options, allowedTypes)
+
+	if err := surveySecretFields(&options, allowedTypes, out); err != nil {
+		log.Fatalf("could not get secret fields: %v", err)
+	}
+
+	surveyTags(options)
+
+	out.Name = options.secretName
+	out.Type = options.secretType
+	out.Tags = options.tags
+
+	if len(options.validate) == 0 {
+		if options.secretType == TypeAmazon ||
+			options.secretType == TypeAzure ||
+			options.secretType == TypeAlibaba ||
+			options.secretType == TypeGoogle ||
+			options.secretType == TypeOracle {
+			// request validation just in case of cloud types
+			prompt := &survey.Confirm{
+				Message: "Do you want to validate this secret?",
+			}
+			_ = survey.AskOne(prompt, &options.validate, nil)
+		}
+	}
+
+	return nil
+}
+
+// surveyGenericSecretType starts to get fields (key/value pair) for generic secret
+func surveyGenericSecretType(out *pipeline.CreateSecretRequest) {
+	out.Values = make(map[string]interface{})
+
+	for {
+
+		// ask for key
+		var key string
+		_ = survey.AskOne(
+			&survey.Input{
+				Message: "Set key field:",
+			},
+			&key,
+			survey.Required,
+		)
+
+		// ask for value
+		var value string
+		_ = survey.AskOne(
+			&survey.Input{
+				Message: "Set value field:",
+			},
+			&value,
+			survey.Required,
+		)
+
+		// add to values field
+		out.Values[key] = value
+
+		// confirm continue
+		isContinue := false
+		prompt := &survey.Confirm{
+			Message: "Do you want to add another key/value pair?",
+		}
+		_ = survey.AskOne(prompt, &isContinue, nil)
+		if !isContinue {
+			return
+		}
+
+	}
+}
+
+// readCreateSecretRequestFromFile reads file from the getting filename into CreateSecretRequest
+func readCreateSecretRequestFromFile(fileName string, out *pipeline.CreateSecretRequest) error {
+	if raw, err := ioutil.ReadFile(fileName); err != nil {
+		return emperror.Wrapf(err, "failed to read file: %s", fileName)
+	} else if err := utils.Unmarshal(raw, &out); err != nil {
+		return emperror.Wrap(err, "failed to parse CreateSecretRequest")
+	}
+	return nil
+}
+
+// surveySecretName starts to get secret name from the user
+func surveySecretName(options *createSecretOptions) {
+	if len(options.secretName) == 0 {
+		_ = survey.AskOne(&survey.Input{Message: "Secret name"}, &options.secretName, survey.Required)
+	}
+}
+
+// surveySecretType starts to get secret type from the user
+func surveySecretType(options *createSecretOptions, allowedTypes map[string]pipeline.AllowedSecretTypeResponse) {
+	if len(options.secretType) == 0 {
+		var typeOptions []string
+		for name := range allowedTypes {
+			typeOptions = append(typeOptions, name)
+		}
+
+		selectTypePrompt := &survey.Select{
+			Message:  "Choose secret type:",
+			Options:  typeOptions,
+			PageSize: 13,
+		}
+		_ = survey.AskOne(selectTypePrompt, &options.secretType, survey.Required)
+	}
+}
+
+// surveySecretFields starts to get secret fields base on selected secret type and pipeline response
+func surveySecretFields(options *createSecretOptions, allowedTypes map[string]pipeline.AllowedSecretTypeResponse, out *pipeline.CreateSecretRequest) error {
+	if options.secretType == TypeGeneric {
+		surveyGenericSecretType(out)
+	} else if allowedSecret, ok := allowedTypes[options.secretType]; ok {
+
+		// set fields
+		fields := allowedSecret.Fields
+		questions := make([]secretFieldQuestion, len(fields))
+		for index, f := range fields {
+
+			// check value mandatory
+			v := survey.Required
+			if !f.Required {
+				v = nil
+			}
+
+			// create question input
+			questions[index] = secretFieldQuestion{
+				name: f.Name,
+				input: &survey.Input{
+					Message: fmt.Sprintf("Set '%s' field:", f.Name),
+					Help:    f.Description,
+				},
+				validator: v,
+			}
+		}
+
+		for i, q := range questions {
+			_ = survey.AskOne(q.input, &questions[i].output, q.validator)
+		}
+
+		// set create secret request fields
+		out.Values = make(map[string]interface{})
+
+		for _, q := range questions {
+			if len(q.output) != 0 {
+				out.Values[q.name] = q.output
+			}
+		}
+	} else {
+		return errors.New("not supported secret type")
+	}
+
+	return nil
+}
+
+// surveyTags starts to get tag(s) for the secret until `skip`
+func surveyTags(options createSecretOptions) {
+
+	if options.tags == nil || len(options.tags) == 0 {
+		isTagAdd := false
+		prompt := &survey.Confirm{
+			Message: "Do you want to add tag(s) to this secret?",
+		}
+		_ = survey.AskOne(prompt, &isTagAdd, nil)
+
+		if isTagAdd {
+			for {
+				var tag string
+				_ = survey.AskOne(
+					&survey.Input{
+						Message: "Tag:",
+						Default: "skip",
+						Help:    "Leave empty to cancel.",
+					},
+					&tag,
+					survey.Required,
+				)
+
+				if tag == "skip" {
+					return
+				}
+
+				options.tags = append(options.tags, tag)
+			}
+		}
+	}
+
+}
+
+func getValidationFlag(validation string) optional.Bool {
+	switch validation {
+	case "false":
+		return optional.NewBool(false)
+	default:
+		return optional.NewBool(true)
+	}
+}

--- a/internal/cli/command/secret/create.go
+++ b/internal/cli/command/secret/create.go
@@ -87,7 +87,8 @@ func NewCreateCommand(banzaiCli cli.Cli) *cobra.Command {
 		Use:     "create",
 		Aliases: []string{"c"},
 		Short:   "Create secret",
-		Long:    "Create secret",
+		Long:    "Create secret based on json stdin or interactive session",
+		SilenceUsage: true,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreateSecret(banzaiCli, options)

--- a/internal/cli/utils/utils.go
+++ b/internal/cli/utils/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cluster
+package utils
 
 import (
 	"bytes"
@@ -22,7 +22,7 @@ import (
 	"github.com/goph/emperror"
 )
 
-func unmarshal(raw []byte, data interface{}) error {
+func Unmarshal(raw []byte, data interface{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(data); err == nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| Related tickets | fixes #19 

```
Usage:
  banzai secret create [flags]

Aliases:
  create, c

Examples:

	Create secret
	---
	$ banzai secret create
	? Secret name mysecretname
	? Choose secret type: password
	? Set 'username' field: myusername
	? Set 'password' field: mypassword
	? Do you want to add tag(s) to this secret? Yes
	? Tag: tag1
	? Tag: tag2
	? Tag: skip

	Create secret with flags
	---
	$ banzai secret create --name mysecretname --type password --tags=cli
	? Set 'username' field: myusername
	? Set 'password' field: mypassword
		

Flags:
  -f, --file string        Secret creation descriptor file
  -h, --help               help for create
  -n, --name string        Name of the secret
      --tags stringArray   Tags to add to the secret
  -t, --type string        Type of the secret
  -v, --validate string    Secret validation (true|false)
```