### PR TITLE
controlplane up/down: add image-tag and image-pull flags

### DIFF
--- a/cmd/docs/banzai_controlplane_down.md
+++ b/cmd/docs/banzai_controlplane_down.md
@@ -13,7 +13,9 @@ banzai controlplane down [flags]
 ### Options
 
 ```
-  -h, --help   help for down
+  -h, --help               help for down
+      --image-pull         Pull cp-installer image even if it's present locally (default true)
+      --image-tag string   Tag of banzaicloud/cp-installer Docker image to use (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/cmd/docs/banzai_controlplane_up.md
+++ b/cmd/docs/banzai_controlplane_up.md
@@ -13,8 +13,10 @@ banzai controlplane up [flags]
 ### Options
 
 ```
-  -f, --file string   Input control plane descriptor file (default "values.yaml")
-  -h, --help          help for up
+  -f, --file string        Input control plane descriptor file (default "values.yaml")
+  -h, --help               help for up
+      --image-pull         Pull cp-installer image even if it's present locally (default true)
+      --image-tag string   Tag of banzaicloud/cp-installer Docker image to use (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20190104022628-a2dfa6d0dab6
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.1
 	github.com/ttacon/chalk v0.0.0-20140724125006-76b3c8b611de
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635

--- a/internal/cli/command/controlplane/down.go
+++ b/internal/cli/command/controlplane/down.go
@@ -26,22 +26,32 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
+type destroyOptions struct {
+	controlPlaneInstallerOptions
+}
+
 // NewDownCommand creates a new cobra.Command for `banzai clontrolplane down`.
 func NewDownCommand() *cobra.Command {
+	options := destroyOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "Destroy the controlplane",
 		Long:  "Destroy a controlplane based on json stdin or interactive session",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDestroy()
+			return runDestroy(options)
 		},
 	}
+
+	flags := cmd.Flags()
+
+	bindInstallerFlags(flags, &options.controlPlaneInstallerOptions)
 
 	return cmd
 }
 
-func runDestroy() error {
+func runDestroy(options destroyOptions) error {
 
 	if isInteractive() {
 		var destroy bool
@@ -86,5 +96,5 @@ func runDestroy() error {
 	}
 
 	log.Info("controlplane is being destroyed")
-	return emperror.Wrap(runInternal("destroy", valuesName, kubeconfigName, tfdir), "controlplane destroy failed")
+	return emperror.Wrap(runInternal("destroy", valuesName, kubeconfigName, tfdir, options.controlPlaneInstallerOptions), "controlplane destroy failed")
 }

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -1,0 +1,53 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
+)
+
+type controlPlaneInstallerOptions struct {
+	installerTag  string
+	pullInstaller bool
+}
+
+func (o *controlPlaneInstallerOptions) pullDockerImage() error {
+
+	args := []string{
+		"pull",
+		fmt.Sprintf("banzaicloud/cp-installer:%s", o.installerTag),
+	}
+
+	log.Info("docker ", strings.Join(args, " "))
+
+	cmd := exec.Command("docker", args...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func bindInstallerFlags(flags *flag.FlagSet, options *controlPlaneInstallerOptions) {
+	flags.StringVarP(&options.installerTag, "image-tag", "", "latest", "Tag of banzaicloud/cp-installer Docker image to use")
+	flags.BoolVarP(&options.pullInstaller, "image-pull", "", true, "Pull cp-installer image even if it's present locally")
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| Related tickets | fixes #74  
| License         | Apache 2.0

banzai cp up
----
```
Create controlplane based on json stdin or interactive session in the current Kubernetes context. The current working directory will be used for storing the applied configuration and deployment status.

Usage:
  banzai controlplane up [flags]

Aliases:
  up, c

Flags:
  -f, --file string                Input control plane descriptor file (default "values.yaml")
  -h, --help                       help for up
      --installer-tag string       Tag of cp-installer (default "latest")
      --installer-tag-force-pull   Pull tag of cp-installer (default true)

Global Flags:
      --color                use colors on non-tty outputs
      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
      --interactive          ask questions interactively even if stdin or stdout is non-tty
      --no-color             never display color output
      --no-interactive       never ask questions interactively
      --organization int32   organization id
  -o, --output string        output format (default|yaml|json) (default "default")
      --verbose              more verbose output
```

banzai cp down
----

```
Destroy a controlplane based on json stdin or interactive session

Usage:
  banzai controlplane down [flags]

Flags:
  -h, --help                       help for down
      --installer-tag string       Tag of cp-installer (default "latest")
      --installer-tag-force-pull   Pull tag of cp-installer (default true)

Global Flags:
      --color                use colors on non-tty outputs
      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
      --interactive          ask questions interactively even if stdin or stdout is non-tty
      --no-color             never display color output
      --no-interactive       never ask questions interactively
      --organization int32   organization id
  -o, --output string        output format (default|yaml|json) (default "default")
      --verbose              more verbose output
```
