### PR TITLE
cluster: sort providers on interactive create survey

### DIFF
--- a/internal/cli/command/cluster/create.go
+++ b/internal/cli/command/cluster/create.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -363,6 +364,7 @@ func buildDefaultRequest(out map[string]interface{}) error {
 	for provider := range providers {
 		providerNames = append(providerNames, provider)
 	}
+	sort.Strings(providerNames)
 
 	var providerName string
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no


### What's in this PR?
Sort the offered cloud provider list instead of presenting them in the natural order of the map keys.
