### PR TITLE
cp: add --refresh-state=true option

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -35,6 +35,7 @@ func runTerraform(command string, options cpContext, banzaiCli cli.Cli, env map[
 		command,
 		"-parallelism=1", // workaround for https://github.com/terraform-providers/terraform-provider-helm/issues/271
 		"-var", "workdir=/root",
+		fmt.Sprintf("-refresh=%v", options.refreshState),
 		"-state=/root/" + tfstateFilename,
 	}
 

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -44,6 +44,7 @@ const (
 type cpContext struct {
 	installerTag  string
 	runLocally    bool
+	refreshState  bool
 	pullInstaller bool
 	autoApprove   bool
 	workspace     string
@@ -81,6 +82,8 @@ func NewContext(cmd *cobra.Command, banzaiCli cli.Cli) *cpContext {
 
 	flags.BoolVar(&ctx.runLocally, "run-locally", false, "Run the terraform command locally instead of docker (for development)")
 	flags.MarkHidden("run-locally")
+	flags.BoolVar(&ctx.refreshState, "refresh-state", true, "Refresh terraform state for each run (turn off to save time during development)")
+	flags.MarkHidden("refresh-state")
 	return &ctx
 }
 

--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -174,9 +174,23 @@ func postInstall(options createOptions, banzaiCli cli.Cli, values map[string]int
 	externalHost, _ := values["externalHost"].(string)
 
 	if externalHost != "auto" && externalHost != defaultLocalhost {
-		if target, err := options.readTraefikAddress(); err != nil {
-			log.Errorf("%v", err)
-		} else {
+		var target string
+		switch values["provider"] {
+		case providerKind:
+			target = "127.0.0.1"
+		case providerEc2:
+			target, err = options.readEc2Host()
+			if err != nil {
+				log.Errorf("%v", err)
+			}
+		case providerK8s:
+			target, err = options.readTraefikAddress()
+			if err != nil {
+				log.Errorf("%v", err)
+			}
+		}
+
+		if target != "" {
 			printExternalHostRecord(externalHost, target)
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes


### What's in this PR?
Add a hidden `--refresh-state` option which can be turned off for quicker deployment during development, and fix external host record hint for all providers.

