### PR TITLE
login: request offline scope and send refresh token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,5 @@ require (
 	k8s.io/client-go v11.0.0+incompatible
 	sigs.k8s.io/kind v0.4.0
 )
+
+go 1.13


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no|yes
| Related tickets | https://github.com/banzaicloud/pipeline/pull/2274 https://github.com/banzaicloud/pipeline/pull/2268
| License         | Apache 2.0


### What's in this PR?
This PR requests the offline OIDC scope and sends the corresponding refresh token to Pipeline as well.

### Why?
Because this is needed after:
- https://github.com/banzaicloud/pipeline/pull/2274
- https://github.com/banzaicloud/pipeline/pull/2268


