### PR TITLE
cp: handle "." and ".." specially

### DIFF
--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -197,8 +197,13 @@ func (c *cpContext) Init() error {
 		c.workspace = "default"
 	}
 
-	if !strings.Contains(c.workspace, string(os.PathSeparator)) {
+	if !strings.Contains(c.workspace, string(os.PathSeparator)) && c.workspace != "." && c.workspace != ".." {
+		original := c.workspace
 		c.workspace = filepath.Join(c.banzaiCli.Home(), "pipeline", c.workspace)
+		if _, err := os.Stat(original); err == nil {
+			original = "./" + original
+			log.Warningf("Using workspace %q instead of %q. Pass --workspace=%q for relative path.", c.workspace, original, original)
+		}
 	}
 
 	var err error
@@ -206,6 +211,8 @@ func (c *cpContext) Init() error {
 	if err != nil {
 		return errors.WrapIff(err, "failed to calculate absolute path to %q", c.workspace)
 	}
+
+	log.Debugf("Using workspace %q.", c.workspace)
 
 	err = os.MkdirAll(c.workspace, 0700)
 	return errors.WrapIff(err, "failed to use %q as workspace path", c.workspace)


### PR DESCRIPTION
and alert the user if a folder named like the workspace exists in the
current pwd

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no

### What's in this PR?

Handle the `.` and `..` special files as a `--workspace` option properly, because it would mean `~/.banzai/pipeline/.` = `~/.banzai/pipeline` and `~/.banzai/pipeline/..` = `~/.banzai` respectively. Now they are handled as relative to the current working directory (just like other paths that contain a slash).

Also, warn the user if `./workspace-name-given` exists.