### PR TITLE
output HTTP requests as curl commands in verbose mode

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -197,7 +197,7 @@ func (c curlRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	log.Debugf("\n%s\n\n", command.String())
+	log.Debug(command.String())
 
 	return c.base.RoundTrip(r)
 }

--- a/internal/cli/command/login/oidc.go
+++ b/internal/cli/command/login/oidc.go
@@ -86,7 +86,7 @@ func runServer(banzaiCli cli.Cli, pipelineBasePath string) (string, error) {
 		pipelineBasePath: pipelineBasePath,
 		banzaiCli:        banzaiCli,
 		client: &http.Client{
-			Transport: banzaiCli.HTTPTransport(),
+			Transport: banzaiCli.RoundTripper(),
 		},
 	}
 

--- a/internal/cli/utils/http2curl.go
+++ b/internal/cli/utils/http2curl.go
@@ -1,0 +1,80 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Modified version of https://github.com/moul/http2curl by Manfred Touron
+
+// CurlCommand contains exec.Command compatible slice + helpers
+type CurlCommand []string
+
+// append appends a string to the CurlCommand
+func (c *CurlCommand) append(newSlice ...string) {
+	*c = append(*c, newSlice...)
+}
+
+// String returns a ready to copy/paste command
+func (c *CurlCommand) String() string {
+	return strings.Join(*c, " ")
+}
+
+func bashEscape(str string) string {
+	return `'` + strings.Replace(str, `'`, `'\''`, -1) + `'`
+}
+
+// GetCurlCommand returns a CurlCommand corresponding to an http.Request
+func GetCurlCommand(req *http.Request, insecureSkipVerify bool) (*CurlCommand, error) {
+	command := CurlCommand{}
+
+	command.append("curl")
+
+	if insecureSkipVerify {
+		command.append("-k")
+	}
+
+	command.append("-X", bashEscape(req.Method))
+
+	keys := make([]string, len(req.Header))
+	for k := range req.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		command.append("-H", bashEscape(fmt.Sprintf("%s: %s", k, strings.Join(req.Header[k], " "))))
+	}
+
+	command.append(bashEscape(req.URL.String()))
+
+	if req.Body != nil {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		bodyEscaped := bashEscape(string(body))
+		command.append("-d", bodyEscaped)
+	}
+
+	return &command, nil
+}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
If started with `--verbose` the CLI will print the executed HTTP requests as cURL commands.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This is really helpful during development and debugging flows.

