### PR TITLE
Improve the support for the DNS cluster feature

### DIFF
--- a/internal/cli/command/cluster/feature/features/activate.go
+++ b/internal/cli/command/cluster/feature/features/activate.go
@@ -21,12 +21,13 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/AlecAivazis/survey/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type activateOptions struct {
@@ -36,7 +37,7 @@ type activateOptions struct {
 
 type ActivateManager interface {
 	GetName() string
-	BuildRequestInteractively(cli.Cli) (*pipeline.ActivateClusterFeatureRequest, error)
+	BuildRequestInteractively(banzaiCli cli.Cli, clusterCtx clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error)
 	ValidateRequest(interface{}) error
 }
 
@@ -76,7 +77,7 @@ func runActivate(
 	var err error
 	var request *pipeline.ActivateClusterFeatureRequest
 	if options.filePath == "" && banzaiCLI.Interactive() {
-		request, err = m.BuildRequestInteractively(banzaiCLI)
+		request, err = m.BuildRequestInteractively(banzaiCLI, options.Context)
 		if err != nil {
 			return errors.WrapIf(err, "failed to build activate request interactively")
 		}

--- a/internal/cli/command/cluster/feature/features/dns/activate.go
+++ b/internal/cli/command/cluster/feature/features/dns/activate.go
@@ -334,8 +334,7 @@ func readExternalDNS(extDnsIn ExternalDNS, actionCtx actionContext) (ExternalDNS
 
 	if actionCtx.providerName != dnsBanzaiCloud {
 		providerQuestions = append(providerQuestions, &survey.Question{
-			Name:
-			"DomainFilters",
+			Name: "DomainFilters",
 			Prompt: &survey.Input{
 				Message: "Please provide domain filters to match domains against:",
 				Default: defaultDomainFilters,
@@ -439,7 +438,7 @@ func getFeatureSpecDefaults(banzaiCLI cli.Cli, clusterCtx clustercontext.Context
 				Name: dnsBanzaiCloud,
 			}
 			retSpec.ClusterDomain = clusterDomain
-			retSpec.ExternalDNS.DomainFilters = strings.Split(clusterDomain, ",")
+			retSpec.ExternalDNS.DomainFilters = []string{clusterDomain}
 			return retSpec, nil
 		}
 
@@ -453,7 +452,7 @@ func getFeatureSpecDefaults(banzaiCLI cli.Cli, clusterCtx clustercontext.Context
 					Name: dnsBanzaiCloud,
 				},
 				// defaults to the clusterdomain
-				DomainFilters: strings.Split(clusterDomain, ","),
+				DomainFilters: []string{clusterDomain},
 			},
 			ClusterDomain: clusterDomain,
 		}, nil

--- a/internal/cli/command/cluster/feature/features/dns/activate.go
+++ b/internal/cli/command/cluster/feature/features/dns/activate.go
@@ -41,7 +41,7 @@ func NewActivateManager() *ActivateManager {
 }
 
 func (ActivateManager) BuildRequestInteractively(banzaiCli cli.Cli, clusterCtx clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error) {
-	builtSpec, err := assembleFeatureRequest(banzaiCli, nil)
+	builtSpec, err := assembleFeatureRequest(banzaiCli, clusterCtx, nil)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to build external DNS feature request")
 	}
@@ -61,7 +61,7 @@ func (ActivateManager) ValidateRequest(req interface{}) error {
 }
 
 // assembleFeatureRequest assembles the request for activate and update the ExternalDNS feature
-func assembleFeatureRequest(banzaiCli cli.Cli, rawSpec interface{}) (map[string]interface{}, error) {
+func assembleFeatureRequest(banzaiCli cli.Cli, clusterCtx clustercontext.Context, rawSpec interface{}) (map[string]interface{}, error) {
 
 	currentDnsFeatureSpec := DNSFeatureSpec{
 		ExternalDNS: ExternalDNS{

--- a/internal/cli/command/cluster/feature/features/dns/activate.go
+++ b/internal/cli/command/cluster/feature/features/dns/activate.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 )
 
@@ -39,8 +40,8 @@ func NewActivateManager() *ActivateManager {
 	return &ActivateManager{}
 }
 
-func (ActivateManager) BuildRequestInteractively(banzaiCLI cli.Cli) (*pipeline.ActivateClusterFeatureRequest, error) {
-	builtSpec, err := assembleFeatureRequest(banzaiCLI, nil)
+func (ActivateManager) BuildRequestInteractively(banzaiCli cli.Cli, clusterCtx clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error) {
+	builtSpec, err := assembleFeatureRequest(banzaiCli, nil)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to build external DNS feature request")
 	}

--- a/internal/cli/command/cluster/feature/features/dns/update.go
+++ b/internal/cli/command/cluster/feature/features/dns/update.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 )
 
 type UpdateManager struct {
@@ -31,14 +32,14 @@ func NewUpdateManager() *UpdateManager {
 	return &UpdateManager{}
 }
 
-func (UpdateManager) BuildRequestInteractively(banzaiCLI cli.Cli, req *pipeline.UpdateClusterFeatureRequest) error {
+func (UpdateManager) BuildRequestInteractively(banzaiCli cli.Cli, updateClusterFeatureRequest *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context) error {
 
-	externalDNS, err := assembleFeatureRequest(banzaiCLI, req.Spec)
+	externalDNS, err := assembleFeatureRequest(banzaiCli, clusterCtx, updateClusterFeatureRequest.Spec)
 	if err != nil {
 		return errors.Wrap(err, "failed to build custom DNS feature request")
 	}
 	// set the modified DNSFeatureSpec into the request
-	req.Spec = externalDNS
+	updateClusterFeatureRequest.Spec = externalDNS
 
 	return nil
 }

--- a/internal/cli/command/cluster/feature/features/monitoring/activate.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/activate.go
@@ -22,8 +22,11 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/antihax/optional"
+
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -31,7 +34,7 @@ type ActivateManager struct {
 	baseManager
 }
 
-func (ActivateManager) BuildRequestInteractively(banzaiCLI cli.Cli) (*pipeline.ActivateClusterFeatureRequest, error) {
+func (ActivateManager) BuildRequestInteractively(banzaiCLI cli.Cli, clusterCtx clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error) {
 
 	grafana, err := askGrafana(banzaiCLI, grafanaSpec{
 		Enabled:    true,

--- a/internal/cli/command/cluster/feature/features/monitoring/update.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/update.go
@@ -18,9 +18,12 @@ import (
 	"encoding/json"
 
 	"emperror.dev/errors"
+
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
-	"github.com/mitchellh/mapstructure"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 )
 
 type UpdateManager struct {
@@ -36,7 +39,7 @@ func (UpdateManager) ValidateRequest(req interface{}) error {
 	return validateSpec(request.Spec)
 }
 
-func (UpdateManager) BuildRequestInteractively(banzaiCLI cli.Cli, req *pipeline.UpdateClusterFeatureRequest) error {
+func (UpdateManager) BuildRequestInteractively(banzaiCLI cli.Cli, req *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context, ) error {
 
 	var spec featureSpec
 	if err := mapstructure.Decode(req.Spec, &spec); err != nil {

--- a/internal/cli/command/cluster/feature/features/securityscan/activate.go
+++ b/internal/cli/command/cluster/feature/features/securityscan/activate.go
@@ -19,11 +19,13 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	"github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/feature/features"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
-	"github.com/mitchellh/mapstructure"
 )
 
 type activateManager struct {
@@ -35,7 +37,7 @@ func NewActivateManager() features.ActivateManager {
 	return new(activateManager)
 }
 
-func (am *activateManager) BuildRequestInteractively(cli.Cli) (*pipeline.ActivateClusterFeatureRequest, error) {
+func (am *activateManager) BuildRequestInteractively(cli.Cli, clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error) {
 	var req pipeline.ActivateClusterFeatureRequest
 
 	var edit bool

--- a/internal/cli/command/cluster/feature/features/securityscan/update.go
+++ b/internal/cli/command/cluster/feature/features/securityscan/update.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	"github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/feature/features"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/mitchellh/mapstructure"
@@ -45,7 +46,7 @@ func (u *updateManager) ValidateRequest(req interface{}) error {
 	return nil
 }
 
-func (u *updateManager) BuildRequestInteractively(cli cli.Cli, req *pipeline.UpdateClusterFeatureRequest) error {
+func (u *updateManager) BuildRequestInteractively(banzaiCli cli.Cli, updateClusterFeatureRequest *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context) error {
 	var edit bool
 	if err := survey.AskOne(&survey.Confirm{Message: "Edit the cluster feature update request in your text editor?"},
 		&edit); err != nil {
@@ -53,10 +54,10 @@ func (u *updateManager) BuildRequestInteractively(cli cli.Cli, req *pipeline.Upd
 	}
 
 	if !edit {
-		return u.buildCustomAnchoreFeatureRequest(req)
+		return u.buildCustomAnchoreFeatureRequest(updateClusterFeatureRequest)
 	}
 
-	content, err := json.MarshalIndent(*req, "", "  ")
+	content, err := json.MarshalIndent(*updateClusterFeatureRequest, "", "  ")
 	if err != nil {
 		return errors.WrapIf(err, "failed to marshal request to JSON")
 	}
@@ -72,7 +73,7 @@ func (u *updateManager) BuildRequestInteractively(cli cli.Cli, req *pipeline.Upd
 		return errors.WrapIf(err, "failure during survey")
 	}
 
-	if err := json.Unmarshal([]byte(result), req); err != nil {
+	if err := json.Unmarshal([]byte(result), updateClusterFeatureRequest); err != nil {
 		return errors.WrapIf(err, "failed to unmarshal JSON as request")
 	}
 

--- a/internal/cli/command/cluster/feature/features/update.go
+++ b/internal/cli/command/cluster/feature/features/update.go
@@ -21,12 +21,13 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/AlecAivazis/survey/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type updateOptions struct {
@@ -37,7 +38,7 @@ type updateOptions struct {
 type UpdateManager interface {
 	GetName() string
 	ValidateRequest(interface{}) error
-	BuildRequestInteractively(cli.Cli, *pipeline.UpdateClusterFeatureRequest) error
+	BuildRequestInteractively(banzaiCli cli.Cli, updateClusterFeatureRequest *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context) error
 }
 
 func UpdateCommandFactory(banzaiCLI cli.Cli, manager UpdateManager, name string) *cobra.Command {
@@ -88,7 +89,7 @@ func runUpdate(
 			Spec: details.Spec,
 		}
 
-		if err := m.BuildRequestInteractively(banzaiCLI, request); err != nil {
+		if err := m.BuildRequestInteractively(banzaiCLI, request, options.Context); err != nil {
 			return errors.WrapIf(err, "failed to build update request interactively")
 		}
 

--- a/internal/cli/command/cluster/feature/features/vault/activate.go
+++ b/internal/cli/command/cluster/feature/features/vault/activate.go
@@ -24,13 +24,14 @@ import (
 	"github.com/antihax/optional"
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 )
 
 type ActivateManager struct{
 	baseManager
 }
 
-func (ActivateManager) BuildRequestInteractively(banzaiCLI cli.Cli) (*pipeline.ActivateClusterFeatureRequest, error) {
+func (ActivateManager) BuildRequestInteractively(banzaiCli cli.Cli, clusterCtx clustercontext.Context) (*pipeline.ActivateClusterFeatureRequest, error) {
 	var request pipeline.ActivateClusterFeatureRequest
 
 	vaultType, err := askVaultComponent(vaultCustom)
@@ -40,7 +41,7 @@ func (ActivateManager) BuildRequestInteractively(banzaiCLI cli.Cli) (*pipeline.A
 
 	switch vaultType {
 	case vaultCustom:
-		customSpec, err := buildCustomVaultFeatureRequest(banzaiCLI, defaults{})
+		customSpec, err := buildCustomVaultFeatureRequest(banzaiCli, defaults{})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to build custom Vault feature request")
 		}


### PR DESCRIPTION
- cluster context (holding the cluster name) inferred to the request assembler methods
Banzai Cloud DNS:
- cluster domain made readonly
- default domain filter set to the cluster domain

Route53
- add region, batchSize options

- Fixed the org domain in case of Banzai Cloud DNS
- Fixed the update flow to  Banzai Cloud DNS

