### PR TITLE
[Monitoring] Make providers of Alertmanager optional

### DIFF
--- a/internal/cli/command/cluster/feature/features/monitoring/activate.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/activate.go
@@ -312,13 +312,21 @@ func askAlertmanager(banzaiCLI cli.Cli, defaults alertmanagerSpec) (*alertmanage
 		}
 
 		// ask provider options
+		const skip = "skip"
 		var notificationProvider string
-		var defaultNotificationProviderValue = alertmanagerNotificationNameSlack
+		var defaultNotificationProviderValue = skip
 		if pdProp, ok := defaults.Provider[alertmanagerProviderPagerDuty]; ok {
 			var pd pagerDutySpec
 			if err := mapstructure.Decode(pdProp, &pd); err == nil {
 				if pd.Enabled {
 					defaultNotificationProviderValue = alertmanagerNotificationNamePagerDuty
+				}
+			}
+		} else if slackProp, ok := defaults.Provider[alertmanagerProviderSlack]; ok {
+			var slack slackSpec
+			if err := mapstructure.Decode(slackProp, &slack); err == nil {
+				if slack.Enabled {
+					defaultNotificationProviderValue = alertmanagerNotificationNameSlack
 				}
 			}
 		}
@@ -331,7 +339,7 @@ func askAlertmanager(banzaiCLI cli.Cli, defaults alertmanagerSpec) (*alertmanage
 					defaultValue: defaultNotificationProviderValue,
 					output:       &notificationProvider,
 				},
-				options: []string{alertmanagerNotificationNameSlack, alertmanagerNotificationNamePagerDuty},
+				options: []string{skip, alertmanagerNotificationNameSlack, alertmanagerNotificationNamePagerDuty},
 			},
 		}); err != nil {
 			return nil, errors.WrapIf(err, "error during getting notification provider")
@@ -349,6 +357,7 @@ func askAlertmanager(banzaiCLI cli.Cli, defaults alertmanagerSpec) (*alertmanage
 			if err != nil {
 				return nil, errors.WrapIf(err, "error during getting PagerDuty provider options")
 			}
+		case skip:
 		default:
 			return nil, errors.NewWithDetails("not supported provider type", "provider", notificationProvider)
 		}

--- a/internal/cli/command/cluster/feature/features/monitoring/spec.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/spec.go
@@ -202,15 +202,11 @@ func (s alertmanagerSpec) Validate() error {
 			return err
 		}
 
-		var hasProvider bool
 		// validate Slack notification provider
 		if slackProv, ok := s.Provider[alertmanagerProviderSlack]; ok {
 			var slack slackSpec
 			if err := mapstructure.Decode(slackProv, &slack); err != nil {
 				return errors.WrapIf(err, "failed to bind Slack config")
-			}
-			if slack.Enabled {
-				hasProvider = true
 			}
 			if err := slack.Validate(); err != nil {
 				return errors.WrapIf(err, "error during validating Slack")
@@ -223,18 +219,10 @@ func (s alertmanagerSpec) Validate() error {
 			if err := mapstructure.Decode(pagerDutyProv, &pd); err != nil {
 				return errors.WrapIf(err, "failed to bind PagerDuty config")
 			}
-			if pd.Enabled {
-				hasProvider = true
-			}
 			if err := pd.Validate(); err != nil {
 				return errors.WrapIf(err, "error during validating PagerDuty")
 			}
 		}
-
-		if !hasProvider {
-			return errors.New("at least one notification provider required")
-		}
-
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Make providers of Alertmanager optional

### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
