### PR TITLE
pipeline: preparing support for remote state

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -135,7 +135,7 @@ func runDocker(command []string, options *cpContext, banzaiCli cli.Cli, env map[
 
 	args := []string{
 		"run", "--rm", "--net=host",
-		// fmt.Sprintf("--user=%d", os.Getuid()), TODO
+		fmt.Sprintf("--user=%d", os.Getuid()),
 		"-v", fmt.Sprintf("%s:/workspace", options.workspace),
 		"-v", fmt.Sprintf("%s:/terraform/state.tf", options.workspace+"/state.tf"),
 		"-v", fmt.Sprintf("%s:/terraform/.terraform/terraform.tfstate", options.workspace+"/.terraform/terraform.tfstate"),

--- a/internal/cli/command/controlplane/init.go
+++ b/internal/cli/command/controlplane/init.go
@@ -299,7 +299,7 @@ func runInit(options initOptions, banzaiCli cli.Cli) error {
 		out["installer"] = map[string]interface{}{"image": strings.TrimSpace(string(ref))}
 	}
 
-	err = initRemoteState(options, banzaiCli)
+	err = initRemoteState(options.cpContext, banzaiCli)
 	if err != nil {
 		return errors.WrapIf(err, "failed to init remote state")
 	}
@@ -307,7 +307,7 @@ func runInit(options initOptions, banzaiCli cli.Cli) error {
 	return options.writeValues(out)
 }
 
-func initRemoteState(options initOptions, banzaiCli cli.Cli) error {
+func initRemoteState(options *cpContext, banzaiCli cli.Cli) error {
 	stateTf := fmt.Sprintf(`terraform {
 		backend "local" {
 			path = "/workspace/%s"
@@ -330,7 +330,7 @@ func initRemoteState(options initOptions, banzaiCli cli.Cli) error {
 	}
 	_ = stateFile.Close()
 
-	if err := runTerraform("init", options.cpContext, banzaiCli, nil); err != nil {
+	if err := runTerraform("init", options, banzaiCli, nil); err != nil {
 		return errors.WrapIf(err, "failed to deploy pipeline components")
 	}
 

--- a/internal/cli/command/controlplane/init.go
+++ b/internal/cli/command/controlplane/init.go
@@ -320,7 +320,7 @@ func initStateBackend(options *cpContext, banzaiCli cli.Cli) error {
 		return errors.WrapIf(err, "failed to create state backend configuration")
 	}
 
-	err = os.Mkdir(options.workspace+"/.terraform", 0700)
+	err = os.MkdirAll(options.workspace+"/.terraform", 0700)
 	if err != nil {
 		return errors.WrapIf(err, "failed to create state backend directory")
 	}

--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -173,10 +173,10 @@ func runUp(options *createOptions, banzaiCli cli.Cli) error {
 		}
 	}
 
-	if !isRemoteStateInited(options) {
-		log.Info("Migrating workspace remote state...")
-		if err := initRemoteState(options.cpContext, banzaiCli); err != nil {
-			return errors.WrapIf(err, "failed to init remote state")
+	if !isStateBackendInited(options) {
+		log.Info("Migrating workspace to state backend...")
+		if err := initStateBackend(options.cpContext, banzaiCli); err != nil {
+			return err
 		}
 	}
 
@@ -199,7 +199,7 @@ func runUp(options *createOptions, banzaiCli cli.Cli) error {
 	return postInstall(options, banzaiCli, values)
 }
 
-func isRemoteStateInited(options *createOptions) bool {
+func isStateBackendInited(options *createOptions) bool {
 	_, err := os.Stat(options.workspace + "/.terraform/terraform.tfstate")
 	if err != nil && os.IsNotExist(err) {
 		return false

--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -183,6 +183,7 @@ func runUp(options *createOptions, banzaiCli cli.Cli) error {
 			env[k] = v
 		}
 	}
+
 	if err := runTerraform("apply", options.cpContext, banzaiCli, env); err != nil {
 		return errors.WrapIf(err, "failed to deploy pipeline components")
 	}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Remote state support preparation for `pipeline up`. Currently, only the same file-based backend (`local`) is used, but in a backend fashion, so extending this with custom remote backends should be straightforward.

- [ ] Don't merge before new image is available