### PR TITLE
terraform can run now in full parallel mode

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -48,7 +48,6 @@ func runTerraform(command string, options *cpContext, banzaiCli cli.Cli, env map
 	if command != "init" {
 
 		cmd = append(cmd, []string{
-			"-parallelism=1", // workaround for https://github.com/terraform-providers/terraform-provider-helm/issues/271
 			"-var", "workdir=/workspace",
 			fmt.Sprintf("-refresh=%v", options.refreshState),
 		}...)


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Terraform was running on one thread until now because of limitations in the installer image. This PR removes that limitation from the CLI.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Since those issues were resolved in the upstream installer image (helm repo update, namespace destroy, etc..) we can remove the single thread limitation thus making the installation process faster.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested on:
- KIND
- Docker for Mac - Kubernetes
- EC2 PKE