### PR TITLE
un-hide banzai cluster feature commands and rename them to service

### DIFF
--- a/cmd/docs/banzai_cluster.md
+++ b/cmd/docs/banzai_cluster.md
@@ -34,5 +34,6 @@ Manage clusters
 * [banzai cluster import](banzai_cluster_import.md)	 - Import an existing cluster (EXPERIMENTAL)
 * [banzai cluster list](banzai_cluster_list.md)	 - List clusters
 * [banzai cluster node](banzai_cluster_node.md)	 - Work with cluster nodes
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
 * [banzai cluster shell](banzai_cluster_shell.md)	 - Start a shell or run a command with the cluster configured as kubectl context
 

--- a/cmd/docs/banzai_cluster_service.md
+++ b/cmd/docs/banzai_cluster_service.md
@@ -1,0 +1,42 @@
+## banzai cluster service
+
+Manage cluster integrated services
+
+### Synopsis
+
+Manage cluster integrated services
+
+```
+banzai cluster service [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to list services
+      --cluster-name string   Name of cluster to list services
+  -h, --help                  help for service
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster](banzai_cluster.md)	 - Manage clusters
+* [banzai cluster service dns](banzai_cluster_service_dns.md)	 - Manage cluster DNS service
+* [banzai cluster service list](banzai_cluster_service_list.md)	 - List active (and pending) integrated services of a cluster
+* [banzai cluster service monitoring](banzai_cluster_service_monitoring.md)	 - Manage cluster Monitoring service
+* [banzai cluster service securityscan](banzai_cluster_service_securityscan.md)	 - Manage cluster securityscan service
+* [banzai cluster service vault](banzai_cluster_service_vault.md)	 - Manage cluster Vault service
+

--- a/cmd/docs/banzai_cluster_service_dns.md
+++ b/cmd/docs/banzai_cluster_service_dns.md
@@ -1,0 +1,41 @@
+## banzai cluster service dns
+
+Manage cluster DNS service
+
+### Synopsis
+
+Manage cluster DNS service
+
+```
+banzai cluster service dns [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to manage DNS cluster service of
+      --cluster-name string   Name of cluster to manage DNS cluster service of
+  -h, --help                  help for dns
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
+* [banzai cluster service dns activate](banzai_cluster_service_dns_activate.md)	 - Activate the DNS service of a cluster
+* [banzai cluster service dns deactivate](banzai_cluster_service_dns_deactivate.md)	 - Deactivate the DNS service of a cluster
+* [banzai cluster service dns get](banzai_cluster_service_dns_get.md)	 - Get details of the DNS service for a cluster
+* [banzai cluster service dns update](banzai_cluster_service_dns_update.md)	 - Update the DNS service of a cluster
+

--- a/cmd/docs/banzai_cluster_service_dns_activate.md
+++ b/cmd/docs/banzai_cluster_service_dns_activate.md
@@ -1,0 +1,38 @@
+## banzai cluster service dns activate
+
+Activate the DNS service of a cluster
+
+### Synopsis
+
+Activate the DNS service of a cluster
+
+```
+banzai cluster service dns activate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to activate DNS cluster service for
+      --cluster-name string   Name of cluster to activate DNS cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for activate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service dns](banzai_cluster_service_dns.md)	 - Manage cluster DNS service
+

--- a/cmd/docs/banzai_cluster_service_dns_deactivate.md
+++ b/cmd/docs/banzai_cluster_service_dns_deactivate.md
@@ -1,0 +1,37 @@
+## banzai cluster service dns deactivate
+
+Deactivate the DNS service of a cluster
+
+### Synopsis
+
+Deactivate the DNS service of a cluster
+
+```
+banzai cluster service dns deactivate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to deactivate DNS cluster service of
+      --cluster-name string   Name of cluster to deactivate DNS cluster service of
+  -h, --help                  help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service dns](banzai_cluster_service_dns.md)	 - Manage cluster DNS service
+

--- a/cmd/docs/banzai_cluster_service_dns_get.md
+++ b/cmd/docs/banzai_cluster_service_dns_get.md
@@ -1,0 +1,37 @@
+## banzai cluster service dns get
+
+Get details of the DNS service for a cluster
+
+### Synopsis
+
+Get details of the DNS service for a cluster
+
+```
+banzai cluster service dns get [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to get DNS cluster service details of
+      --cluster-name string   Name of cluster to get DNS cluster service details of
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service dns](banzai_cluster_service_dns.md)	 - Manage cluster DNS service
+

--- a/cmd/docs/banzai_cluster_service_dns_update.md
+++ b/cmd/docs/banzai_cluster_service_dns_update.md
@@ -1,0 +1,38 @@
+## banzai cluster service dns update
+
+Update the DNS service of a cluster
+
+### Synopsis
+
+Update the DNS service of a cluster
+
+```
+banzai cluster service dns update [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to update DNS cluster service for
+      --cluster-name string   Name of cluster to update DNS cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service dns](banzai_cluster_service_dns.md)	 - Manage cluster DNS service
+

--- a/cmd/docs/banzai_cluster_service_list.md
+++ b/cmd/docs/banzai_cluster_service_list.md
@@ -1,0 +1,37 @@
+## banzai cluster service list
+
+List active (and pending) integrated services of a cluster
+
+### Synopsis
+
+List active (and pending) integrated services of a cluster
+
+```
+banzai cluster service list [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to list services
+      --cluster-name string   Name of cluster to list services
+  -h, --help                  help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
+

--- a/cmd/docs/banzai_cluster_service_monitoring.md
+++ b/cmd/docs/banzai_cluster_service_monitoring.md
@@ -1,0 +1,41 @@
+## banzai cluster service monitoring
+
+Manage cluster Monitoring service
+
+### Synopsis
+
+Manage cluster Monitoring service
+
+```
+banzai cluster service monitoring [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to manage Monitoring cluster service of
+      --cluster-name string   Name of cluster to manage Monitoring cluster service of
+  -h, --help                  help for monitoring
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
+* [banzai cluster service monitoring activate](banzai_cluster_service_monitoring_activate.md)	 - Activate the Monitoring service of a cluster
+* [banzai cluster service monitoring deactivate](banzai_cluster_service_monitoring_deactivate.md)	 - Deactivate the Monitoring service of a cluster
+* [banzai cluster service monitoring get](banzai_cluster_service_monitoring_get.md)	 - Get details of the Monitoring service for a cluster
+* [banzai cluster service monitoring update](banzai_cluster_service_monitoring_update.md)	 - Update the Monitoring service of a cluster
+

--- a/cmd/docs/banzai_cluster_service_monitoring_activate.md
+++ b/cmd/docs/banzai_cluster_service_monitoring_activate.md
@@ -1,0 +1,38 @@
+## banzai cluster service monitoring activate
+
+Activate the Monitoring service of a cluster
+
+### Synopsis
+
+Activate the Monitoring service of a cluster
+
+```
+banzai cluster service monitoring activate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to activate Monitoring cluster service for
+      --cluster-name string   Name of cluster to activate Monitoring cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for activate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service monitoring](banzai_cluster_service_monitoring.md)	 - Manage cluster Monitoring service
+

--- a/cmd/docs/banzai_cluster_service_monitoring_deactivate.md
+++ b/cmd/docs/banzai_cluster_service_monitoring_deactivate.md
@@ -1,0 +1,37 @@
+## banzai cluster service monitoring deactivate
+
+Deactivate the Monitoring service of a cluster
+
+### Synopsis
+
+Deactivate the Monitoring service of a cluster
+
+```
+banzai cluster service monitoring deactivate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to deactivate Monitoring cluster service of
+      --cluster-name string   Name of cluster to deactivate Monitoring cluster service of
+  -h, --help                  help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service monitoring](banzai_cluster_service_monitoring.md)	 - Manage cluster Monitoring service
+

--- a/cmd/docs/banzai_cluster_service_monitoring_get.md
+++ b/cmd/docs/banzai_cluster_service_monitoring_get.md
@@ -1,0 +1,37 @@
+## banzai cluster service monitoring get
+
+Get details of the Monitoring service for a cluster
+
+### Synopsis
+
+Get details of the Monitoring service for a cluster
+
+```
+banzai cluster service monitoring get [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to get Monitoring cluster service details of
+      --cluster-name string   Name of cluster to get Monitoring cluster service details of
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service monitoring](banzai_cluster_service_monitoring.md)	 - Manage cluster Monitoring service
+

--- a/cmd/docs/banzai_cluster_service_monitoring_update.md
+++ b/cmd/docs/banzai_cluster_service_monitoring_update.md
@@ -1,0 +1,38 @@
+## banzai cluster service monitoring update
+
+Update the Monitoring service of a cluster
+
+### Synopsis
+
+Update the Monitoring service of a cluster
+
+```
+banzai cluster service monitoring update [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to update Monitoring cluster service for
+      --cluster-name string   Name of cluster to update Monitoring cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service monitoring](banzai_cluster_service_monitoring.md)	 - Manage cluster Monitoring service
+

--- a/cmd/docs/banzai_cluster_service_securityscan.md
+++ b/cmd/docs/banzai_cluster_service_securityscan.md
@@ -1,0 +1,41 @@
+## banzai cluster service securityscan
+
+Manage cluster securityscan service
+
+### Synopsis
+
+Manage cluster securityscan service
+
+```
+banzai cluster service securityscan [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to manage securityscan cluster service of
+      --cluster-name string   Name of cluster to manage securityscan cluster service of
+  -h, --help                  help for securityscan
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
+* [banzai cluster service securityscan activate](banzai_cluster_service_securityscan_activate.md)	 - Activate the securityscan service of a cluster
+* [banzai cluster service securityscan deactivate](banzai_cluster_service_securityscan_deactivate.md)	 - Deactivate the securityscan service of a cluster
+* [banzai cluster service securityscan get](banzai_cluster_service_securityscan_get.md)	 - Get details of the securityscan service for a cluster
+* [banzai cluster service securityscan update](banzai_cluster_service_securityscan_update.md)	 - Update the securityscan service of a cluster
+

--- a/cmd/docs/banzai_cluster_service_securityscan_activate.md
+++ b/cmd/docs/banzai_cluster_service_securityscan_activate.md
@@ -1,0 +1,38 @@
+## banzai cluster service securityscan activate
+
+Activate the securityscan service of a cluster
+
+### Synopsis
+
+Activate the securityscan service of a cluster
+
+```
+banzai cluster service securityscan activate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to activate securityscan cluster service for
+      --cluster-name string   Name of cluster to activate securityscan cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for activate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service securityscan](banzai_cluster_service_securityscan.md)	 - Manage cluster securityscan service
+

--- a/cmd/docs/banzai_cluster_service_securityscan_deactivate.md
+++ b/cmd/docs/banzai_cluster_service_securityscan_deactivate.md
@@ -1,0 +1,37 @@
+## banzai cluster service securityscan deactivate
+
+Deactivate the securityscan service of a cluster
+
+### Synopsis
+
+Deactivate the securityscan service of a cluster
+
+```
+banzai cluster service securityscan deactivate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to deactivate securityscan cluster service of
+      --cluster-name string   Name of cluster to deactivate securityscan cluster service of
+  -h, --help                  help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service securityscan](banzai_cluster_service_securityscan.md)	 - Manage cluster securityscan service
+

--- a/cmd/docs/banzai_cluster_service_securityscan_get.md
+++ b/cmd/docs/banzai_cluster_service_securityscan_get.md
@@ -1,0 +1,37 @@
+## banzai cluster service securityscan get
+
+Get details of the securityscan service for a cluster
+
+### Synopsis
+
+Get details of the securityscan service for a cluster
+
+```
+banzai cluster service securityscan get [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to get securityscan cluster service details of
+      --cluster-name string   Name of cluster to get securityscan cluster service details of
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service securityscan](banzai_cluster_service_securityscan.md)	 - Manage cluster securityscan service
+

--- a/cmd/docs/banzai_cluster_service_securityscan_update.md
+++ b/cmd/docs/banzai_cluster_service_securityscan_update.md
@@ -1,0 +1,38 @@
+## banzai cluster service securityscan update
+
+Update the securityscan service of a cluster
+
+### Synopsis
+
+Update the securityscan service of a cluster
+
+```
+banzai cluster service securityscan update [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to update securityscan cluster service for
+      --cluster-name string   Name of cluster to update securityscan cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service securityscan](banzai_cluster_service_securityscan.md)	 - Manage cluster securityscan service
+

--- a/cmd/docs/banzai_cluster_service_vault.md
+++ b/cmd/docs/banzai_cluster_service_vault.md
@@ -1,0 +1,41 @@
+## banzai cluster service vault
+
+Manage cluster Vault service
+
+### Synopsis
+
+Manage cluster Vault service
+
+```
+banzai cluster service vault [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to manage Vault cluster service of
+      --cluster-name string   Name of cluster to manage Vault cluster service of
+  -h, --help                  help for vault
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service](banzai_cluster_service.md)	 - Manage cluster integrated services
+* [banzai cluster service vault activate](banzai_cluster_service_vault_activate.md)	 - Activate the Vault service of a cluster
+* [banzai cluster service vault deactivate](banzai_cluster_service_vault_deactivate.md)	 - Deactivate the Vault service of a cluster
+* [banzai cluster service vault get](banzai_cluster_service_vault_get.md)	 - Get details of the Vault service for a cluster
+* [banzai cluster service vault update](banzai_cluster_service_vault_update.md)	 - Update the Vault service of a cluster
+

--- a/cmd/docs/banzai_cluster_service_vault_activate.md
+++ b/cmd/docs/banzai_cluster_service_vault_activate.md
@@ -1,0 +1,38 @@
+## banzai cluster service vault activate
+
+Activate the Vault service of a cluster
+
+### Synopsis
+
+Activate the Vault service of a cluster
+
+```
+banzai cluster service vault activate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to activate Vault cluster service for
+      --cluster-name string   Name of cluster to activate Vault cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for activate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service vault](banzai_cluster_service_vault.md)	 - Manage cluster Vault service
+

--- a/cmd/docs/banzai_cluster_service_vault_deactivate.md
+++ b/cmd/docs/banzai_cluster_service_vault_deactivate.md
@@ -1,0 +1,37 @@
+## banzai cluster service vault deactivate
+
+Deactivate the Vault service of a cluster
+
+### Synopsis
+
+Deactivate the Vault service of a cluster
+
+```
+banzai cluster service vault deactivate [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to deactivate Vault cluster service of
+      --cluster-name string   Name of cluster to deactivate Vault cluster service of
+  -h, --help                  help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service vault](banzai_cluster_service_vault.md)	 - Manage cluster Vault service
+

--- a/cmd/docs/banzai_cluster_service_vault_get.md
+++ b/cmd/docs/banzai_cluster_service_vault_get.md
@@ -1,0 +1,37 @@
+## banzai cluster service vault get
+
+Get details of the Vault service for a cluster
+
+### Synopsis
+
+Get details of the Vault service for a cluster
+
+```
+banzai cluster service vault get [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to get Vault cluster service details of
+      --cluster-name string   Name of cluster to get Vault cluster service details of
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service vault](banzai_cluster_service_vault.md)	 - Manage cluster Vault service
+

--- a/cmd/docs/banzai_cluster_service_vault_update.md
+++ b/cmd/docs/banzai_cluster_service_vault_update.md
@@ -1,0 +1,38 @@
+## banzai cluster service vault update
+
+Update the Vault service of a cluster
+
+### Synopsis
+
+Update the Vault service of a cluster
+
+```
+banzai cluster service vault update [flags]
+```
+
+### Options
+
+```
+      --cluster int32         ID of cluster to update Vault cluster service for
+      --cluster-name string   Name of cluster to update Vault cluster service for
+  -f, --file string           Feature specification file
+  -h, --help                  help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --color                use colors on non-tty outputs
+      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
+      --interactive          ask questions interactively even if stdin or stdout is non-tty
+      --no-color             never display color output
+      --no-interactive       never ask questions interactively
+      --organization int32   organization id
+  -o, --output string        output format (default|yaml|json) (default "default")
+      --verbose              more verbose output
+```
+
+### SEE ALSO
+
+* [banzai cluster service vault](banzai_cluster_service_vault.md)	 - Manage cluster Vault service
+

--- a/cmd/docs/banzai_pipeline_down.md
+++ b/cmd/docs/banzai_pipeline_down.md
@@ -13,11 +13,13 @@ banzai pipeline down [flags]
 ### Options
 
 ```
-      --auto-approve       Automatically approve the changes to deploy (default true)
-  -h, --help               help for down
-      --image-pull         Pull cp-installer image even if it's present locally (default true)
-      --image-tag string   Tag of banzaicloud/cp-installer Docker image to use (default "latest")
-      --workspace string   Name of directory for storing the applied configuration and deployment status
+      --auto-approve               Automatically approve the changes to deploy (default true)
+      --container-runtime string   Run the terraform command with "docker", "containerd" (crictl) or "exec" (execute locally) (default "auto")
+  -h, --help                       help for down
+      --image string               Name of Docker image repository to use (default "docker.io/banzaicloud/pipeline-installer")
+      --image-pull                 Pull installer image even if it's present locally (default true)
+      --image-tag string           Tag of installer Docker image to use (default "latest")
+      --workspace string           Name of directory for storing the applied configuration and deployment status
 ```
 
 ### Options inherited from parent commands

--- a/cmd/docs/banzai_pipeline_init.md
+++ b/cmd/docs/banzai_pipeline_init.md
@@ -6,11 +6,11 @@ Initialize configuration for Banzai Cloud Pipeline
 
 Prepare a workspace for the deployment of an instance of Banzai Cloud Pipeline based on a values file or an interactive session.
 
-Depending on the --provider selection, the installer will work in the current Kubernetes context (k8s), deploy a KIND (Kubernetes in Docker) cluster to the local machine (kind), or deploy a PKE cluster in Amazon EC2 (ec2).
+Depending on the --provider selection, the installer will work in the current Kubernetes context (k8s), deploy a KIND (Kubernetes in Docker) cluster to the local machine (kind), install a single-node PKE cluster (pke), or deploy a PKE cluster in Amazon EC2 (ec2).
 
 The directory specified with --workspace, set in the installer.workspace key of the config, or $BANZAI_INSTALLER_WORKSPACE (default: ~/.banzai/pipeline/default) will be used for storing the applied configuration and deployment status.
 
-The command requires docker to be accessible in the system and able to run containers.
+The command requires docker or ctr (containerd) to be accessible in the system and able to run containers.
 
 The input file will be copied to the workspace during initialization. Further changes can be done there before re-running the command (without --file).
 
@@ -21,13 +21,15 @@ banzai pipeline init [flags]
 ### Options
 
 ```
-      --auto-approve       Automatically approve the changes to deploy (default true)
-  -f, --file string        Input Banzai Cloud Pipeline instance descriptor file
-  -h, --help               help for init
-      --image-pull         Pull cp-installer image even if it's present locally (default true)
-      --image-tag string   Tag of banzaicloud/cp-installer Docker image to use (default "latest")
-      --provider string    Provider of the infrastructure for the deployment (k8s|kind|ec2)
-      --workspace string   Name of directory for storing the applied configuration and deployment status
+      --auto-approve               Automatically approve the changes to deploy (default true)
+      --container-runtime string   Run the terraform command with "docker", "containerd" (crictl) or "exec" (execute locally) (default "auto")
+  -f, --file string                Input Banzai Cloud Pipeline instance descriptor file
+  -h, --help                       help for init
+      --image string               Name of Docker image repository to use (default "docker.io/banzaicloud/pipeline-installer")
+      --image-pull                 Pull installer image even if it's present locally (default true)
+      --image-tag string           Tag of installer Docker image to use (default "latest")
+      --provider string            Provider of the infrastructure for the deployment (k8s|kind|ec2|pke)
+      --workspace string           Name of directory for storing the applied configuration and deployment status
 ```
 
 ### Options inherited from parent commands

--- a/cmd/docs/banzai_pipeline_up.md
+++ b/cmd/docs/banzai_pipeline_up.md
@@ -6,11 +6,11 @@ Deploy Banzai Cloud Pipeline
 
 Deploy or upgrade an instance of Banzai Cloud Pipeline based on a values file in the workspace, or initialize the workspace from an input file or an interactive session.
 
-Depending on the --provider selection, the installer will work in the current Kubernetes context (k8s), deploy a KIND (Kubernetes in Docker) cluster to the local machine (kind), or deploy a PKE cluster in Amazon EC2 (ec2).
+Depending on the --provider selection, the installer will work in the current Kubernetes context (k8s), deploy a KIND (Kubernetes in Docker) cluster to the local machine (kind), install a single-node PKE cluster (pke), or deploy a PKE cluster in Amazon EC2 (ec2).
 
 The directory specified with --workspace, set in the installer.workspace key of the config, or $BANZAI_INSTALLER_WORKSPACE (default: ~/.banzai/pipeline/default) will be used for storing the applied configuration and deployment status.
 
-The command requires docker to be accessible in the system and able to run containers.
+The command requires docker or ctr (containerd) to be accessible in the system and able to run containers.
 
 The input file will be copied to the workspace during initialization. Further changes can be done there before re-running the command (without --file).
 
@@ -21,14 +21,16 @@ banzai pipeline up [flags]
 ### Options
 
 ```
-      --auto-approve       Automatically approve the changes to deploy (default true)
-  -f, --file string        Input Banzai Cloud Pipeline instance descriptor file
-  -h, --help               help for up
-      --image-pull         Pull cp-installer image even if it's present locally (default true)
-      --image-tag string   Tag of banzaicloud/cp-installer Docker image to use (default "latest")
-  -i, --init               Initialize workspace
-      --provider string    Provider of the infrastructure for the deployment (k8s|kind|ec2)
-      --workspace string   Name of directory for storing the applied configuration and deployment status
+      --auto-approve               Automatically approve the changes to deploy (default true)
+      --container-runtime string   Run the terraform command with "docker", "containerd" (crictl) or "exec" (execute locally) (default "auto")
+  -f, --file string                Input Banzai Cloud Pipeline instance descriptor file
+  -h, --help                       help for up
+      --image string               Name of Docker image repository to use (default "docker.io/banzaicloud/pipeline-installer")
+      --image-pull                 Pull installer image even if it's present locally (default true)
+      --image-tag string           Tag of installer Docker image to use (default "latest")
+  -i, --init                       Initialize workspace
+      --provider string            Provider of the infrastructure for the deployment (k8s|kind|ec2|pke)
+      --workspace string           Name of directory for storing the applied configuration and deployment status
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/command/cluster/feature/cmd.go
+++ b/internal/cli/command/cluster/feature/cmd.go
@@ -32,7 +32,6 @@ func NewFeatureCommand(banzaiCli cli.Cli) *cobra.Command {
 		Aliases: []string{"features", "feat", "ft"},
 		Short:   "Manage cluster features",
 		Args:    cobra.MaximumNArgs(1),
-		Hidden:  true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runList(banzaiCli, options, args)
 		},

--- a/internal/cli/command/cluster/feature/cmd.go
+++ b/internal/cli/command/cluster/feature/cmd.go
@@ -28,16 +28,16 @@ func NewFeatureCommand(banzaiCli cli.Cli) *cobra.Command {
 	options := listOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "feature",
-		Aliases: []string{"features", "feat", "ft"},
-		Short:   "Manage cluster features",
+		Use:     "service",
+		Aliases: []string{"services", "svc", "feature"},
+		Short:   "Manage cluster integrated services",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runList(banzaiCli, options, args)
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "list features")
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "list services")
 
 	cmd.AddCommand(
 		NewListCommand(banzaiCli),
@@ -69,12 +69,12 @@ func featureCommandFactory(banzaiCLI cli.Cli, use string, scm SubCommandManager)
 
 	cmd := &cobra.Command{
 		Use:   use,
-		Short: fmt.Sprintf("Manage cluster %s feature", scm.GetName()),
+		Short: fmt.Sprintf("Manage cluster %s service", scm.GetName()),
 		Args:  cobra.NoArgs,
 		RunE:  getCommand.RunE,
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("manage %s cluster feature of", scm.GetName()))
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("manage %s cluster service of", scm.GetName()))
 
 	cmd.AddCommand(
 		features.ActivateCommandFactory(banzaiCLI, scm.ActivateManager(), scm.GetName()),

--- a/internal/cli/command/cluster/feature/features/activate.go
+++ b/internal/cli/command/cluster/feature/features/activate.go
@@ -47,7 +47,7 @@ func ActivateCommandFactory(banzaiCli cli.Cli, manager ActivateManager, name str
 	cmd := &cobra.Command{
 		Use:           "activate",
 		Aliases:       []string{"add", "enable", "install", "on"},
-		Short:         fmt.Sprintf("Activate the %s feature of a cluster", name),
+		Short:         fmt.Sprintf("Activate the %s service of a cluster", name),
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,7 +56,7 @@ func ActivateCommandFactory(banzaiCli cli.Cli, manager ActivateManager, name str
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, fmt.Sprintf("activate %s cluster feature for", name))
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, fmt.Sprintf("activate %s cluster service for", name))
 
 	flags := cmd.Flags()
 	flags.StringVarP(&options.filePath, "file", "f", "", "Feature specification file")
@@ -88,7 +88,7 @@ func runActivate(
 
 	} else {
 		if err := readActivateReqFromFileOrStdin(options.filePath, request); err != nil {
-			return errors.WrapIf(err, fmt.Sprintf("failed to read %s cluster feature specification", m.GetName()))
+			return errors.WrapIf(err, fmt.Sprintf("failed to read %s cluster service specification", m.GetName()))
 		}
 	}
 
@@ -96,11 +96,11 @@ func runActivate(
 	clusterId := options.ClusterID()
 	_, err = banzaiCLI.Client().ClusterFeaturesApi.ActivateClusterFeature(context.Background(), orgId, clusterId, m.GetName(), *request)
 	if err != nil {
-		cli.LogAPIError(fmt.Sprintf("activate %s cluster feature", m.GetName()), err, request)
-		log.Fatalf("could not activate %s cluster feature: %v", m.GetName(), err)
+		cli.LogAPIError(fmt.Sprintf("activate %s cluster service", m.GetName()), err, request)
+		log.Fatalf("could not activate %s cluster service: %v", m.GetName(), err)
 	}
 
-	log.Infof("feature %q started to activate", m.GetName())
+	log.Infof("service %q started to activate", m.GetName())
 
 	return nil
 }
@@ -122,7 +122,7 @@ func showActivateEditor(m ActivateManager, req *pipeline.ActivateClusterFeatureR
 	var edit bool
 	if err := survey.AskOne(
 		&survey.Confirm{
-			Message: "Do you want to edit the cluster feature activation request in your text editor?",
+			Message: "Do you want to edit the cluster service activation request in your text editor?",
 		},
 		&edit,
 	); err != nil {

--- a/internal/cli/command/cluster/feature/features/deactivate.go
+++ b/internal/cli/command/cluster/feature/features/deactivate.go
@@ -39,14 +39,14 @@ func DeactivateCommandFactory(banzaiCli cli.Cli, manager DeactivateManager, name
 	cmd := &cobra.Command{
 		Use:     "deactivate",
 		Aliases: []string{"disable", "off", "remove", "rm", "uninstall"},
-		Short:   fmt.Sprintf("Deactivate the %s feature of a cluster", name),
+		Short:   fmt.Sprintf("Deactivate the %s service of a cluster", name),
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runDeactivate(banzaiCli, manager, options, args)
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, fmt.Sprintf("deactivate %s cluster feature of", name))
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, fmt.Sprintf("deactivate %s cluster service of", name))
 
 	return cmd
 }
@@ -67,11 +67,11 @@ func runDeactivate(
 
 	resp, err := pipeline.ClusterFeaturesApi.DeactivateClusterFeature(context.Background(), orgId, clusterId, m.GetName())
 	if err != nil {
-		cli.LogAPIError(fmt.Sprintf("deactivate %s cluster feature", m.GetName()), err, resp.Request)
-		log.Fatalf("could not deactivate %s cluster feature: %v", m.GetName(), err)
+		cli.LogAPIError(fmt.Sprintf("deactivate %s cluster service", m.GetName()), err, resp.Request)
+		log.Fatalf("could not deactivate %s cluster service: %v", m.GetName(), err)
 	}
 
-	log.Infof("feature %q started to deactivate", m.GetName())
+	log.Infof("service %q started to deactivate", m.GetName())
 
 	return nil
 }

--- a/internal/cli/command/cluster/feature/features/dns/activate.go
+++ b/internal/cli/command/cluster/feature/features/dns/activate.go
@@ -54,7 +54,7 @@ func (ActivateManager) BuildRequestInteractively(banzaiCli cli.Cli, clusterCtx c
 
 	builtSpec, err := assembleFeatureRequest(banzaiCli, clusterCtx, defaultSpec, NewActionContext(actionNew))
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to build external DNS feature request")
+		return nil, errors.WrapIf(err, "failed to build external DNS service request")
 	}
 
 	return &pipeline.ActivateClusterFeatureRequest{
@@ -405,7 +405,7 @@ func getSecretsForProvider(banzaiCLI cli.Cli, dnsProvider string) (featureutils.
 func getFeatureSpecDefaults(banzaiCLI cli.Cli, clusterCtx clustercontext.Context, specIn DNSFeatureSpec, actionCtx actionContext) (DNSFeatureSpec, error) {
 	switch actionCtx.providerName {
 	case dnsBanzaiCloud:
-		caps, r, err := banzaiCLI.Client().PipelineApi.ListCapabilities(context.Background(), )
+		caps, r, err := banzaiCLI.Client().PipelineApi.ListCapabilities(context.Background())
 		if err := featureutils.CheckCallResults(r, err); err != nil {
 			return DNSFeatureSpec{}, errors.WrapIf(err, "failed to retrieve capabilities")
 		}

--- a/internal/cli/command/cluster/feature/features/dns/common.go
+++ b/internal/cli/command/cluster/feature/features/dns/common.go
@@ -78,7 +78,7 @@ func validateSpec(specObj map[string]interface{}) error {
 	var dnsSpec DNSFeatureSpec
 
 	if err := mapstructure.Decode(specObj, &dnsSpec); err != nil {
-		return errors.WrapIf(err, "feature specification does not conform to schema")
+		return errors.WrapIf(err, "service specification does not conform to schema")
 	}
 
 	err := dnsSpec.ExternalDNS.Validate()
@@ -126,9 +126,9 @@ func assembleFeatureRequest(banzaiCli cli.Cli, clusterCtx clustercontext.Context
 	}
 
 	actionContext.SetProvider(selectedProviderInfo.Name)
-	dnsFeatureSpec, err = getFeatureSpecDefaults(banzaiCli, clusterCtx, dnsFeatureSpec, actionContext);
+	dnsFeatureSpec, err = getFeatureSpecDefaults(banzaiCli, clusterCtx, dnsFeatureSpec, actionContext)
 	if err != nil {
-		return nil, errors.WrapIf(err, "failed to get dns feature defaults")
+		return nil, errors.WrapIf(err, "failed to get dns service defaults")
 	}
 	dnsFeatureSpec.ExternalDNS.Provider = &selectedProviderInfo
 

--- a/internal/cli/command/cluster/feature/features/dns/update.go
+++ b/internal/cli/command/cluster/feature/features/dns/update.go
@@ -44,13 +44,13 @@ func (UpdateManager) BuildRequestInteractively(banzaiCli cli.Cli, updateClusterF
 	if updateClusterFeatureRequest.Spec != nil {
 		// update feature case
 		if err := mapstructure.Decode(updateClusterFeatureRequest.Spec, &currentDnsFeatureSpec); err != nil {
-			return errors.WrapIf(err, "failed to decode feature DNSFeatureSpec")
+			return errors.WrapIf(err, "failed to decode service DNSFeatureSpec")
 		}
 	}
 
 	externalDNS, err := assembleFeatureRequest(banzaiCli, clusterCtx, currentDnsFeatureSpec, NewActionContext(actionUpdate))
 	if err != nil {
-		return errors.Wrap(err, "failed to build custom DNS feature request")
+		return errors.Wrap(err, "failed to build custom DNS service request")
 	}
 	// set the modified DNSFeatureSpec into the request
 	updateClusterFeatureRequest.Spec = externalDNS

--- a/internal/cli/command/cluster/feature/features/get.go
+++ b/internal/cli/command/cluster/feature/features/get.go
@@ -44,14 +44,14 @@ func GetCommandFactory(banzaiCLI cli.Cli, manager GetManager, name string) *cobr
 	cmd := &cobra.Command{
 		Use:     "get",
 		Aliases: []string{"details", "show", "query"},
-		Short:   fmt.Sprintf("Get details of the %s feature for a cluster", name),
+		Short:   fmt.Sprintf("Get details of the %s service for a cluster", name),
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runGet(banzaiCLI, manager, options, args)
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("get %s cluster feature details of", name))
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("get %s cluster service details of", name))
 
 	return cmd
 }
@@ -73,13 +73,13 @@ func runGet(
 	details, resp, err := pipelineClient.ClusterFeaturesApi.ClusterFeatureDetails(context.Background(), orgId, clusterId, m.GetName())
 
 	if resp.StatusCode == http.StatusNotFound {
-		log.Printf("cluster feature [%s] not found", m.GetName())
+		log.Printf("cluster service [%s] not found", m.GetName())
 		return nil
 	}
 
 	if err != nil {
-		cli.LogAPIError(fmt.Sprintf("get %s cluster feature details", m.GetName()), err, resp.Request)
-		log.Fatalf("could not get %s cluster feature details: %v", m.GetName(), err)
+		cli.LogAPIError(fmt.Sprintf("get %s cluster service details", m.GetName()), err, resp.Request)
+		log.Fatalf("could not get %s cluster service details: %v", m.GetName(), err)
 		return err
 	}
 

--- a/internal/cli/command/cluster/feature/features/monitoring/common.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/common.go
@@ -61,7 +61,7 @@ func validateSpec(specObj map[string]interface{}) error {
 	var spec featureSpec
 
 	if err := mapstructure.Decode(specObj, &spec); err != nil {
-		return errors.WrapIf(err, "feature specification does not conform to schema")
+		return errors.WrapIf(err, "service specification does not conform to schema")
 	}
 
 	return spec.Validate()

--- a/internal/cli/command/cluster/feature/features/monitoring/update.go
+++ b/internal/cli/command/cluster/feature/features/monitoring/update.go
@@ -39,11 +39,11 @@ func (UpdateManager) ValidateRequest(req interface{}) error {
 	return validateSpec(request.Spec)
 }
 
-func (UpdateManager) BuildRequestInteractively(banzaiCLI cli.Cli, req *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context, ) error {
+func (UpdateManager) BuildRequestInteractively(banzaiCLI cli.Cli, req *pipeline.UpdateClusterFeatureRequest, clusterCtx clustercontext.Context) error {
 
 	var spec featureSpec
 	if err := mapstructure.Decode(req.Spec, &spec); err != nil {
-		return errors.WrapIf(err, "feature specification does not conform to schema")
+		return errors.WrapIf(err, "service specification does not conform to schema")
 	}
 
 	grafana, err := askGrafana(banzaiCLI, spec.Grafana)

--- a/internal/cli/command/cluster/feature/features/securityscan/update.go
+++ b/internal/cli/command/cluster/feature/features/securityscan/update.go
@@ -56,17 +56,17 @@ func (um updateManager) BuildRequestInteractively(banzaiCLI cli.Cli, updateClust
 
 	featureSpec := SecurityScanFeatureSpec{}
 	if err := mapstructure.Decode(updateClusterFeatureRequest.Spec, &featureSpec); err != nil {
-		return errors.WrapIf(err, "failed to decode feature specification for update")
+		return errors.WrapIf(err, "failed to decode service specification for update")
 	}
 
 	featureSpec, err := um.assembleFeatureSpec(context.Background(), banzaiCLI.Context().OrganizationID(), clusterCtx.ClusterID(), featureSpec)
 	if err != nil {
-		return errors.WrapIf(err, "failed to assemble feature specification")
+		return errors.WrapIf(err, "failed to assemble service specification")
 	}
 
 	featureSpecMap, err := um.securityScanSpecAsMap(&featureSpec)
 	if err != nil {
-		return errors.WrapIf(err, "failed to transform feature specification")
+		return errors.WrapIf(err, "failed to transform service specification")
 	}
 
 	updateClusterFeatureRequest.Spec = featureSpecMap

--- a/internal/cli/command/cluster/feature/features/update.go
+++ b/internal/cli/command/cluster/feature/features/update.go
@@ -47,14 +47,14 @@ func UpdateCommandFactory(banzaiCLI cli.Cli, manager UpdateManager, name string)
 	cmd := &cobra.Command{
 		Use:     "update",
 		Aliases: []string{"change", "modify", "set"},
-		Short:   fmt.Sprintf("Update the %s feature of a cluster", name),
+		Short:   fmt.Sprintf("Update the %s service of a cluster", name),
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runUpdate(banzaiCLI, manager, options, args)
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("update %s cluster feature for", name))
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCLI, fmt.Sprintf("update %s cluster service for", name))
 
 	flags := cmd.Flags()
 	flags.StringVarP(&options.filePath, "file", "f", "", "Feature specification file")
@@ -82,7 +82,7 @@ func runUpdate(
 		// get feature details
 		details, _, err := banzaiCLI.Client().ClusterFeaturesApi.ClusterFeatureDetails(context.Background(), orgID, clusterID, m.GetName())
 		if err != nil {
-			return errors.WrapIf(err, "failed to get feature details")
+			return errors.WrapIf(err, "failed to get service details")
 		}
 
 		request = &pipeline.UpdateClusterFeatureRequest{
@@ -100,17 +100,17 @@ func runUpdate(
 
 	} else {
 		if err := readUpdateReqFromFileOrStdin(options.filePath, request); err != nil {
-			return errors.WrapIf(err, fmt.Sprintf("failed to read %s cluster feature specification", m.GetName()))
+			return errors.WrapIf(err, fmt.Sprintf("failed to read %s cluster service specification", m.GetName()))
 		}
 	}
 
 	resp, err := banzaiCLI.Client().ClusterFeaturesApi.UpdateClusterFeature(context.Background(), orgID, clusterID, m.GetName(), *request)
 	if err != nil {
-		cli.LogAPIError(fmt.Sprintf("update %s cluster feature", m.GetName()), err, resp.Request)
-		log.Fatalf("could not update %s cluster feature: %v", m.GetName(), err)
+		cli.LogAPIError(fmt.Sprintf("update %s cluster service", m.GetName()), err, resp.Request)
+		log.Fatalf("could not update %s cluster service: %v", m.GetName(), err)
 	}
 
-	log.Infof("feature %q started to update", m.GetName())
+	log.Infof("service %q started to update", m.GetName())
 
 	return nil
 }
@@ -132,7 +132,7 @@ func showUpdateEditor(m UpdateManager, request *pipeline.UpdateClusterFeatureReq
 	var edit bool
 	if err := survey.AskOne(
 		&survey.Confirm{
-			Message: "Do you want to edit the cluster feature update request in your text editor?",
+			Message: "Do you want to edit the cluster service update request in your text editor?",
 		},
 		&edit,
 	); err != nil {

--- a/internal/cli/command/cluster/feature/list.go
+++ b/internal/cli/command/cluster/feature/list.go
@@ -35,14 +35,14 @@ func NewListCommand(banzaiCli cli.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List active (and pending) features of a cluster",
+		Short:   "List active (and pending) integrated services of a cluster",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runList(banzaiCli, options, args)
 		},
 	}
 
-	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "list features")
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "list services")
 
 	return cmd
 }
@@ -59,8 +59,8 @@ func runList(banzaiCli cli.Cli, options listOptions, args []string) error {
 
 	list, resp, err := pipeline.ClusterFeaturesApi.ListClusterFeatures(context.Background(), orgId, clusterId)
 	if err != nil {
-		cli.LogAPIError("list cluster features", err, resp.Request)
-		log.Fatalf("could not list cluster features: %v", err)
+		cli.LogAPIError("list cluster services", err, resp.Request)
+		log.Fatalf("could not list cluster services: %v", err)
 	}
 
 	type row struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
`banzai cluster service` commands are shown in the help messages.
