### PR TITLE
cp: fix panic on empty non-interactive stdin

### DIFF
--- a/internal/cli/command/controlplane/init.go
+++ b/internal/cli/command/controlplane/init.go
@@ -158,6 +158,9 @@ func runInit(options initOptions, banzaiCli cli.Cli) error {
 		err = utils.Unmarshal(raw, &out)
 		if err != nil {
 			return errors.WrapIf(err, "failed to parse descriptor")
+		} else if out == nil {
+			log.Info("no configuration provided on stdin")
+			out = make(map[string]interface{})
 		}
 
 		if provider, ok := out["provider"].(string); ok && provider != "" {


### PR DESCRIPTION
```banzai cp init --no-interactive --image=pipeline-installer --image-pull=false --image-tag=local --provider kind
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/banzaicloud/banzai-cli/internal/cli/command/controlplane.runInit(0x0, 0x0, 0x7ffdc3e942e2, 0x4, 0xc0001d1f10, 0x19f7660, 0xc0001e41e0, 0x0, 0xc000141c90)
	/home/circleci/project/internal/cli/command/controlplane/init.go:170 +0x21aa
```

| Q               | A
| --------------- | ---
| Bug fix?        | yes
