### PR TITLE
Preapply hook 

### DIFF
--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -192,6 +192,12 @@ func runUp(options *createOptions, banzaiCli cli.Cli) error {
 		}
 	}
 
+	// this is required for scenarios where we need precomputed
+	// variables present before apply e.g. when merging multiple values files into a single config
+	if err := runTerraform("apply", options.cpContext, banzaiCli, env, "null_resource.preapply_hook"); err != nil {
+		return errors.WrapIf(err, "failed to run null_resource.preapply_hook as a standalone target")
+	}
+
 	if err := runTerraform("apply", options.cpContext, banzaiCli, env); err != nil {
 		return errors.WrapIf(err, "failed to deploy pipeline components")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Makes nothing if the resource is not present. Required when computed values used in resource `count`.

### Why?
In case we use a computed value from a resource to set the count for another resource the following error happens:
```
Error: Invalid count argument

  on asd.tf line 8, in data "template_file" "asd":
   8:   count    = var.enabled ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```
As the error message suggest we have to run the resources in question using the `-target` argument before running the whole apply.
We can run this "hook" before `apply` even if the resource `null_resource.preapply_hook` does not exist, because terraform will simply ignore it.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
