### PR TITLE
cp: enable remote state configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7
+	github.com/json-iterator/go v1.1.6
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2

--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -253,7 +253,7 @@ func runTerraformCommandGeneric(options *cpContext, cmd []string, cmdEnv map[str
 	case runtimeDocker:
 		args := []string{
 			"-v", fmt.Sprintf("%s:/workspace", options.workspace),
-			"-v", fmt.Sprintf("%s:/terraform/state.tf", options.workspace+"/state.tf"),
+			"-v", fmt.Sprintf("%s:/terraform/state.tf.json", options.workspace+"/state.tf.json"),
 			"-v", fmt.Sprintf("%s:/terraform/.terraform/terraform.tfstate", options.workspace+"/.terraform/terraform.tfstate"),
 		}
 		if options.banzaiCli.Interactive() {
@@ -266,7 +266,7 @@ func runTerraformCommandGeneric(options *cpContext, cmd []string, cmdEnv map[str
 	case runtimeContainerd:
 		args := []string{
 			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/workspace,options=rbind:rw", options.workspace),
-			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/state.tf,options=rbind:rw", options.workspace+"/state.tf"),
+			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/state.tf.json,options=rbind:rw", options.workspace+"/state.tf.json"),
 			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/.terraform/terraform.tfstate,options=rbind:rw", options.workspace+"/.terraform/terraform.tfstate"),
 		}
 		if options.banzaiCli.Interactive() {

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -161,6 +161,10 @@ func (c *cpContext) tfstatePath() string {
 }
 
 func (c *cpContext) deleteTfstate() error {
+	_, err := os.Stat(c.tfstatePath())
+	if os.IsNotExist(err) {
+		return nil
+	}
 	return os.Remove(c.tfstatePath())
 }
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adding support for storing installer state in Terraform `remote state` backends: https://www.terraform.io/docs/backends/types/remote.html

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
#### How to use

1. `banzai cp init`

2. Add the following snippet to the `~/.banzai/pipeline/default/values.yaml` file:
```yaml
state:
  terraform:
    backend:
      s3:
        bucket: my-tf-bucket
        key: "path/to/my/key"
        region: "eu-west-1"
        access_key: ******
        secret_key: ******
```
3. `banzai cp up`