### PR TITLE
installer: force-copy remote state on init

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -56,6 +56,8 @@ func runTerraform(command string, options *cpContext, env map[string]string, tar
 			fmt.Sprintf("-refresh=%v", options.refreshState),
 		}...)
 
+		cmd = append(cmd, "-input=false", "-force-copy")
+
 		if options.AutoApprove() {
 			cmd = append(cmd, "-auto-approve")
 		}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Don't ask any questions on init and force copy remote state to new backend.


