### PR TITLE
Terraform init backend config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 /dist/
 /vendor/
+/tmp/
 .DS_Store
 
 # packr files https://github.com/gobuffalo/packr/tree/master/v2

--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -65,6 +65,10 @@ func runTerraform(command string, options *cpContext, env map[string]string, tar
 		}
 	} else {
 		cmd = append(cmd, "-input=false", "-force-copy")
+
+		if fileExists(filepath.Join(options.workspace, "state.tfvars")) {
+			cmd = append(cmd, "-backend-config", "/workspace/state.tfvars")
+		}
 	}
 
 	return runTerraformCommandGeneric(options, cmd, cmdEnv)

--- a/internal/cli/command/controlplane/utils.go
+++ b/internal/cli/command/controlplane/utils.go
@@ -1,0 +1,26 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import "os"
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return !info.IsDir()
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
`banzai pipeline` commands provide a `backend-config` file for `terraform init` command, if a `state.tfvars` file is found in the workspace.


### Why?
This change lets us provide state backend credentials in an uncommited file.
