### PR TITLE
Generate cli docs in hugo-style markdown, to include them in the main…

### DIFF
--- a/cmd/docs/generate.go
+++ b/cmd/docs/generate.go
@@ -15,7 +15,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/banzaicloud/banzai-cli/cmd"
 	"github.com/spf13/cobra/doc"

--- a/cmd/docs/generate.go
+++ b/cmd/docs/generate.go
@@ -23,8 +23,29 @@ import (
 
 func main() {
 	cmd.Init("", "", "", "")
+
+	const fmTemplate = `---
+title: %s
+slug: %s
+---
+
+> This file was generated automatically. Do not modify it.
+
+`
+	const basePath = "/docs/pipeline/cli/reference/"
+
+	// Customized Hugo output based on https://github.com/spf13/cobra/blob/master/doc/md_docs.md
+	filePrepender := func(filename string) string {
+		name := filepath.Base(filename)
+		base := strings.TrimSuffix(name, path.Ext(name))
+		return fmt.Sprintf(fmTemplate, strings.Replace(base, "_", " ", -1), base)
+	}
+	linkHandler := func(name string) string {
+		base := strings.TrimSuffix(name, path.Ext(name))
+		return basePath + strings.ToLower(base) + "/"
+	}
 	c := cmd.GetRootCommand()
-	err := doc.GenMarkdownTree(c, ".")
+	err := doc.GenMarkdownTreeCustom(c, ".", filePrepender, linkHandler)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
… banzaicloud doc site

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Changes the way the automated command-line docs are generated, so the docs can be incorporated into the main banzaicloud.com doc site.

### Why?
So the CLI docs can be included in the main doc site in HTML format.
