### PR TITLE
Allow changing the cluster name from the command line

### DIFF
--- a/internal/cli/command/cluster/create.go
+++ b/internal/cli/command/cluster/create.go
@@ -318,10 +318,6 @@ func buildInteractiveCreateRequest(banzaiCli cli.Cli, options createOptions, org
 		}
 	}
 
-	if options.name != "" {
-		out["name"] = options.name
-	}
-
 	if out["cloud"] == nil && out["type"] == nil {
 		err := buildDefaultRequest(out)
 		if err != nil {
@@ -343,6 +339,10 @@ func buildInteractiveCreateRequest(banzaiCli cli.Cli, options createOptions, org
 	secretID, err := buildSecretChoice(banzaiCli, orgID, cloud, out)
 	if err != nil {
 		return err
+	}
+
+	if options.name != "" {
+		out["name"] = options.name
 	}
 
 	if out["name"] == nil || out["name"] == "" {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Allow changing the cluster name from the command line:

```
banzai cluster create --name my-cluster -f descriptor.json
```


### Why?
When using predefined templates updating the name manually in the cluster descriptor is painful. 

