### PR TITLE
up: mount original tfstate for migrate

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -262,6 +262,9 @@ func runTerraformCommandGeneric(options *cpContext, cmd []string, cmdEnv map[str
 			"-v", fmt.Sprintf("%s:/terraform/state.tf.json", options.workspace+"/state.tf.json"),
 			"-v", fmt.Sprintf("%s:/terraform/.terraform/terraform.tfstate", options.workspace+"/.terraform/terraform.tfstate"),
 		}
+		if options.tfstateExists() {
+			args = append(args, "-v", fmt.Sprintf("%s:/terraform/terraform.tfstate", options.tfstatePath()))
+		}
 		if options.banzaiCli.Interactive() {
 			args = append(args, "-ti")
 		}
@@ -274,6 +277,9 @@ func runTerraformCommandGeneric(options *cpContext, cmd []string, cmdEnv map[str
 			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/workspace,options=rbind:rw", options.workspace),
 			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/state.tf.json,options=rbind:rw", options.workspace+"/state.tf.json"),
 			"--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/.terraform/terraform.tfstate,options=rbind:rw", options.workspace+"/.terraform/terraform.tfstate"),
+		}
+		if options.tfstateExists() {
+			args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s,dst=/terraform/terraform.tfstate,options=rbind:rw", options.tfstatePath()))
 		}
 		if options.banzaiCli.Interactive() {
 			args = append(args, "-t")

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -160,6 +160,11 @@ func (c *cpContext) tfstatePath() string {
 	return filepath.Join(c.workspace, tfstateFilename)
 }
 
+func (c *cpContext) tfstateExists() bool {
+	_, err := os.Stat(c.tfstatePath())
+	return err == nil
+}
+
 func (c *cpContext) deleteTfstate() error {
 	_, err := os.Stat(c.tfstatePath())
 	if os.IsNotExist(err) {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Mounting the original tfstate file to the working directory before state migration.

### Why?
Otherwise, the migration will get completed without any state.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Installer image required: 0.4.11