### PR TITLE
add client header to requests

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -199,6 +199,8 @@ func (c curlRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	log.Debug(command.String())
 
+	r.Header.Add("Client", "banzai-cli")
+
 	return c.base.RoundTrip(r)
 }
 

--- a/internal/cli/command/login/oidc.go
+++ b/internal/cli/command/login/oidc.go
@@ -311,13 +311,12 @@ func (a *app) requestTokenFromPipeline(rawIDToken string, refreshToken string) (
 		return "", fmt.Errorf("request returned: %s", string(body))
 	}
 
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "user_sess" {
-			return cookie.Value, nil
-		}
+	sessionToken := resp.Header.Get("Authorization")
+	if sessionToken != "" {
+		return sessionToken, nil
 	}
 
-	return "", fmt.Errorf("failed to find user_sess cookie in Pipeline response")
+	return "", fmt.Errorf("failed to find Authorization header in Pipeline response")
 }
 
 func (a *app) waitShutdown(server *http.Server) {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pipeline/pull/2860
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A `Client` (similarly to the `Server` header) header is added, so servers can detect the CLI.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
