### PR TITLE
Add cluster config command

### DIFF
--- a/internal/cli/command/cluster/cmd.go
+++ b/internal/cli/command/cluster/cmd.go
@@ -39,6 +39,7 @@ func NewClusterCommand(banzaiCli cli.Cli) *cobra.Command {
 		NewImportCommand(banzaiCli),
 		NewListCommand(banzaiCli),
 		NewShellCommand(banzaiCli),
+		NewConfigCommand(banzaiCli),
 		integratedservice.NewIntegratedServiceCommand(banzaiCli),
 		node.NewNodeCommand(banzaiCli),
 		nodepool.NewNodePoolCommand(banzaiCli),

--- a/internal/cli/command/cluster/config.go
+++ b/internal/cli/command/cluster/config.go
@@ -1,0 +1,70 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type configOptions struct {
+	clustercontext.Context
+}
+
+func NewConfigCommand(banzaiCli cli.Cli) *cobra.Command {
+	options := configOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "config [--cluster=ID | [--cluster-name=]NAME]",
+		Aliases: []string{"co"},
+		Short:   "Get K8S config",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDownloadConfig(banzaiCli, options, args)
+		},
+	}
+	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "config")
+
+	return cmd
+}
+
+func runDownloadConfig(banzaiCli cli.Cli, options configOptions, args []string) error {
+	if err := options.Init(args...); err != nil {
+		return err
+	}
+
+	orgId := banzaiCli.Context().OrganizationID()
+	id := options.ClusterID()
+
+	config, _, err := banzaiCli.Client().ClustersApi.GetClusterConfig(context.Background(), orgId, id)
+	if err != nil {
+		return errors.WrapIf(err, "could not get cluster config")
+	}
+
+	err = ioutil.WriteFile(fmt.Sprintf("%s.yaml", options.ClusterName()), []byte(config.Data), 0644)
+	if err != nil {
+		return errors.WrapIf(err, "failed to write initial repository config")
+	}
+
+	log.Infof("K8S config saved: %s", options.ClusterName())
+
+	return nil
+}

--- a/internal/cli/command/cluster/config.go
+++ b/internal/cli/command/cluster/config.go
@@ -20,10 +20,11 @@ import (
 	"io/ioutil"
 
 	"emperror.dev/errors"
-	"github.com/banzaicloud/banzai-cli/internal/cli"
-	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/banzaicloud/banzai-cli/internal/cli"
+	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
 )
 
 type configOptions struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Support to download K8S config to the current folder.

### Usage
```
Get K8S config

Usage:
  banzai cluster config [--cluster=ID | [--cluster-name=]NAME] [flags]

Aliases:
  config, co

Flags:
      --cluster int32         ID of cluster to config
      --cluster-name string   Name of cluster to config
  -h, --help                  help for config
  -p, --path string           Path to save cluster K8S config

Global Flags:
      --color                use colors on non-tty outputs
      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
      --interactive          ask questions interactively even if stdin or stdout is non-tty
      --no-color             never display color output
      --no-interactive       never ask questions interactively
      --organization int32   organization id
  -o, --output string        output format (default|yaml|json) (default "default")
      --verbose              more verbose output
```


### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
