### PR TITLE
Add config flag to cluster shell command

### DIFF
--- a/internal/cli/command/cluster/shell.go
+++ b/internal/cli/command/cluster/shell.go
@@ -174,11 +174,11 @@ func runShell(banzaiCli cli.Cli, options shellOptions, args []string) error {
 		// write config file into temp file
 		raw, err := ioutil.ReadFile(options.configFile)
 		if err != nil {
-			return errors.WrapIff(err, "failed to load file", "filename", options.configFile)
+			return errors.WrapIfWithDetails(err, "failed to load file", "filename", options.configFile)
 		}
 
 		if err := writeConfigData(raw, tmpfile); err != nil {
-			return errors.WrapIff(err, "failed to read file", "filename", options.configFile)
+			return errors.WrapIfWithDetails(err, "failed to read file", "filename", options.configFile)
 		}
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add new `config` flag to cluster shell command

### Why?
Allow config files out of shell (or OIDC config files) to be used


### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
