### PR TITLE
add nodepool update cancel and tail subcommand

### DIFF
--- a/internal/cli/command/cluster/nodepool/create.go
+++ b/internal/cli/command/cluster/nodepool/create.go
@@ -40,7 +40,7 @@ func NewCreateCommand(banzaiCli cli.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create a new node pool",
+		Short:   "Create a node pool",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/internal/cli/command/cluster/nodepool/update.go
+++ b/internal/cli/command/cluster/nodepool/update.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/banzai-cli/.gen/pipeline"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
 	clustercontext "github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/context"
+	"github.com/banzaicloud/banzai-cli/internal/cli/command/cluster/nodepool/update"
 	"github.com/banzaicloud/banzai-cli/internal/cli/utils"
 	"github.com/banzaicloud/banzai-cli/pkg/process"
 	log "github.com/sirupsen/logrus"
@@ -39,7 +40,7 @@ func NewUpdateCommand(banzaiCli cli.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [NAME]",
 		Aliases: []string{"u"},
-		Short:   "Update a node pool",
+		Short:   "Update a node pool (and related subcommands)",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -49,11 +50,13 @@ func NewUpdateCommand(banzaiCli cli.Cli) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
+	flags := cmd.LocalFlags()
 
 	flags.StringVarP(&options.file, "file", "f", "", "Node pool descriptor file")
 
 	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "update")
+
+	cmd.AddCommand(update.NewCancelCommand(banzaiCli))
 
 	return cmd
 }

--- a/internal/cli/command/cluster/nodepool/update.go
+++ b/internal/cli/command/cluster/nodepool/update.go
@@ -56,7 +56,10 @@ func NewUpdateCommand(banzaiCli cli.Cli) *cobra.Command {
 
 	options.Context = clustercontext.NewClusterContext(cmd, banzaiCli, "update")
 
-	cmd.AddCommand(update.NewCancelCommand(banzaiCli))
+	cmd.AddCommand(
+		update.NewCancelCommand(banzaiCli),
+		update.NewTailCommand(banzaiCli),
+	)
 
 	return cmd
 }

--- a/internal/cli/command/cluster/nodepool/update/cancel.go
+++ b/internal/cli/command/cluster/nodepool/update/cancel.go
@@ -1,0 +1,73 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/banzai-cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+// NewCancelCommand creates a new cobra.Command for `banzai cluster nodepool update cancel`.
+func NewCancelCommand(banzaiCli cli.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel processId",
+		Short: "Cancel a node pool update",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCancelUpdate(banzaiCli, args)
+		},
+	}
+
+	return cmd
+}
+
+func runCancelUpdate(banzaiCli cli.Cli, args []string) error {
+	id := args[0]
+
+	p, resp, err := banzaiCli.Client().ProcessesApi.GetProcess(context.Background(), banzaiCli.Context().OrganizationID(), id)
+	if err != nil {
+		cli.LogAPIError("cancel node pool update", err, resp)
+
+		return errors.WrapIf(err, "failed to cancel node pool update")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		err := errors.NewWithDetails("node pool update cancel failed with http status code", "status_code", resp.StatusCode)
+
+		cli.LogAPIError("cancel node pool update", err, resp)
+
+		return err
+	}
+
+	if !strings.HasSuffix(p.Type, "update-node-pool") {
+		return errors.New("not a nodepool update process")
+	}
+
+	_, err = banzaiCli.Client().ProcessesApi.CancelProcess(context.Background(), banzaiCli.Context().OrganizationID(), id)
+	if err != nil {
+		// TODO: review log usage
+		return errors.WrapIf(err, "failed to cancel node pool update")
+	}
+
+	_, _ = fmt.Fprintf(banzaiCli.Out(), "update process %q canceled\n", id)
+
+	return nil
+}

--- a/internal/cli/command/cluster/nodepool/update/tail.go
+++ b/internal/cli/command/cluster/nodepool/update/tail.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package process
+package update
 
 import (
 	"github.com/banzaicloud/banzai-cli/internal/cli"
@@ -20,11 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewTailCommand creates a new cobra.Command for `banzai process tail`.
+// NewTailCommand creates a new cobra.Command for `banzai cluster nodepool update tail`.
 func NewTailCommand(banzaiCli cli.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tail processId",
-		Short: "Tail a process",
+		Short: "Tail a node pool update",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTail(banzaiCli, args)
@@ -35,5 +35,12 @@ func NewTailCommand(banzaiCli cli.Cli) *cobra.Command {
 }
 
 func runTail(banzaiCli cli.Cli, args []string) error {
-	return process.TailProcess(banzaiCli, args[0])
+	processID := args[0]
+
+	err := checkUpdateProcess(banzaiCli, processID)
+	if err != nil {
+		return err
+	}
+
+	return process.TailProcess(banzaiCli, processID)
 }

--- a/internal/cli/command/cluster/nodepool/update/util.go
+++ b/internal/cli/command/cluster/nodepool/update/util.go
@@ -1,0 +1,42 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"context"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/banzaicloud/banzai-cli/internal/cli"
+)
+
+func checkUpdateProcess(banzaiCli cli.Cli, processID string) error {
+	p, resp, err := banzaiCli.Client().ProcessesApi.GetProcess(context.Background(), banzaiCli.Context().OrganizationID(), processID)
+	if err != nil {
+		return errors.WrapIf(err, "failed to read node pool update process")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		err := errors.NewWithDetails("reading node pool update process failed with http status code", "status_code", resp.StatusCode)
+		return err
+	}
+
+	if !strings.HasSuffix(p.Type, "update-node-pool") {
+		return errors.New("not a node pool update process")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | #235
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Move out hidden process subcommands to `cluster nodepool update` specific forms.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Usage examples:
```
$ banzai cluster nodepool update tail 06017cef-d1c2-4a2e-a07a-fd0f4b40755b
$ banzai cluster nodepool update cancel 06017cef-d1c2-4a2e-a07a-fd0f4b40755b
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
