### PR TITLE
fix process error handling

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.1 h1:qgMbHoJbPbw579P+1zVY+6n4nIFuIchaIjzZ/I/Yq8M=
-github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=

--- a/internal/cli/command/cluster/nodepool/update/cancel.go
+++ b/internal/cli/command/cluster/nodepool/update/cancel.go
@@ -30,6 +30,9 @@ func NewCancelCommand(banzaiCli cli.Cli) *cobra.Command {
 		Short: "Cancel a node pool update",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
 			return runCancelUpdate(banzaiCli, args)
 		},
 	}
@@ -47,7 +50,6 @@ func runCancelUpdate(banzaiCli cli.Cli, args []string) error {
 
 	_, err = banzaiCli.Client().ProcessesApi.CancelProcess(context.Background(), banzaiCli.Context().OrganizationID(), processID)
 	if err != nil {
-		// TODO: review log usage
 		return errors.WrapIf(err, "failed to cancel node pool update")
 	}
 

--- a/internal/cli/command/cluster/nodepool/update/tail.go
+++ b/internal/cli/command/cluster/nodepool/update/tail.go
@@ -27,6 +27,9 @@ func NewTailCommand(banzaiCli cli.Cli) *cobra.Command {
 		Short: "Tail a node pool update",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
 			return runTail(banzaiCli, args)
 		},
 	}
@@ -42,5 +45,10 @@ func runTail(banzaiCli cli.Cli, args []string) error {
 		return err
 	}
 
-	return process.TailProcess(banzaiCli, processID)
+	err = process.TailProcess(banzaiCli, processID)
+	if err != nil && !process.IsProcessFailedError(err) {
+		return err
+	}
+
+	return nil
 }

--- a/internal/cli/command/process/cancel.go
+++ b/internal/cli/command/process/cancel.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,21 +29,24 @@ func NewCancelCommand(banzaiCli cli.Cli) *cobra.Command {
 		Use:   "cancel processId",
 		Short: "Cancel a process",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			runCancel(banzaiCli, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			return runCancel(banzaiCli, args)
 		},
 	}
 
 	return cmd
 }
 
-func runCancel(banzaiCli cli.Cli, args []string) {
+func runCancel(banzaiCli cli.Cli, args []string) error {
 	id := args[0]
 	_, err := banzaiCli.Client().ProcessesApi.CancelProcess(context.Background(), banzaiCli.Context().OrganizationID(), id)
 	if err != nil {
-		// TODO: review log usage
-		log.Fatalf("could not cancel process: %v", err)
+		return errors.Wrap(err, "could not cancel process")
 	}
 
-	_, _ = fmt.Fprintf(banzaiCli.Out(), "process %q canceled\n", id)
+	_, err = fmt.Fprintf(banzaiCli.Out(), "process %q canceled\n", id)
+	return err
 }

--- a/internal/cli/command/process/list.go
+++ b/internal/cli/command/process/list.go
@@ -56,7 +56,6 @@ func runList(banzaiCli cli.Cli, options listOptions) error {
 
 	processes, _, err := banzaiCli.Client().ProcessesApi.ListProcesses(context.Background(), banzaiCli.Context().OrganizationID(), &o)
 	if err != nil {
-		// TODO: review log usage
 		return errors.Wrap(err, "could not list processes")
 	}
 

--- a/internal/cli/command/process/tail.go
+++ b/internal/cli/command/process/tail.go
@@ -27,6 +27,9 @@ func NewTailCommand(banzaiCli cli.Cli) *cobra.Command {
 		Short: "Tail a process",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
 			return runTail(banzaiCli, args)
 		},
 	}
@@ -35,5 +38,10 @@ func NewTailCommand(banzaiCli cli.Cli) *cobra.Command {
 }
 
 func runTail(banzaiCli cli.Cli, args []string) error {
-	return process.TailProcess(banzaiCli, args[0])
+	err := process.TailProcess(banzaiCli, args[0])
+	if err != nil && !process.IsProcessFailedError(err) {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -28,6 +28,19 @@ import (
 
 const processVisibleThreshold = 3
 
+type ProcessFailedError struct {
+	msg string
+}
+
+func (e ProcessFailedError) Error() string {
+	return e.msg
+}
+
+func IsProcessFailedError(err error) bool {
+	_, ok := err.(ProcessFailedError)
+	return ok
+}
+
 func TailProcess(banzaiCli cli.Cli, processId string) error {
 	client := banzaiCli.Client()
 	orgID := banzaiCli.Context().OrganizationID()
@@ -91,7 +104,7 @@ func TailProcess(banzaiCli cli.Cli, processId string) error {
 			_, _ = fmt.Fprintf(banzaiCli.Out(), "%s process finished", process.Type)
 			return nil
 		} else if process.Status != pipeline.RUNNING {
-			return errors.New(fmt.Sprintf("%s process %s: %s", process.Type, process.Status, process.Log))
+			return ProcessFailedError{fmt.Sprintf("%s process %s: %s", process.Type, process.Status, process.Log)}
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Standard error handling for process-related commands without printing usage after failure.
- Tail commands don't error if process failed/canceled.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
