### PR TITLE
fix cluster context in org without clusters

### DIFF
--- a/internal/cli/command/cluster/context/context.go
+++ b/internal/cli/command/cluster/context/context.go
@@ -93,7 +93,7 @@ func (c *clusterContext) Init(args ...string) error {
 	}
 
 	if len(clusters) == 0 {
-		return errors.WrapIf(err, "there are no clusters in the organization")
+		return errors.New("there are no clusters in the organization")
 	}
 
 	if c.name == "" {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Error handling was broken for empty organizations.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This caused the CLI to send a malformed request to Pipeline where `clusterID` was 0, instead of returning a "404"-ish error to the user.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
