### PR TITLE
Helm3 support

### DIFF
--- a/internal/cli/command/cluster/helm.go
+++ b/internal/cli/command/cluster/helm.go
@@ -100,7 +100,6 @@ func writeHelm(url, name string) error {
 }
 
 func runHelm(banzaiCli cli.Cli, options helmOptions, args []string) error {
-
 	env := os.Environ()
 	envs := make(map[string]string, len(env))
 	for _, pair := range env {
@@ -119,12 +118,18 @@ func runHelm(banzaiCli cli.Cli, options helmOptions, args []string) error {
 			return err
 		}
 		envs, err = setHelm2Env(envs, banzaiCli)
+		if err != nil {
+			return err
+		}
 	} else {
 		version, err = getHelmVersion(banzaiCli)
 		if err != nil {
 			return err
 		}
 		envs, err = setHelmEnv(envs, banzaiCli)
+		if err != nil {
+			return err
+		}
 	}
 
 	name, err := getHelmBinary(version, banzaiCli)

--- a/internal/cli/command/cluster/helm.go
+++ b/internal/cli/command/cluster/helm.go
@@ -112,6 +112,7 @@ func runHelm(banzaiCli cli.Cli, options helmOptions, args []string) error {
 
 	var version string
 	var err error
+	// TODO remove after helm2 eol
 	if options.version == "2" {
 		version, err = tillerVersion()
 		if err != nil {
@@ -126,9 +127,24 @@ func runHelm(banzaiCli cli.Cli, options helmOptions, args []string) error {
 		if err != nil {
 			return err
 		}
-		envs, err = setHelmEnv(envs, banzaiCli)
-		if err != nil {
-			return err
+		// TODO remove after helm2 eol
+		if version == "" {
+			version, err = tillerVersion()
+			if err != nil {
+				return err
+			}
+			envs, err = setHelm2Env(envs, banzaiCli)
+			if err != nil {
+				return err
+			}
+		} else {
+			if tiller, _ := tillerVersion(); tiller != "" {
+				log.Warn("Helm version 2 is deprecated but tiller is found on the cluster. Please migrate to helm version 3.")
+			}
+			envs, err = setHelmEnv(envs, banzaiCli)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -271,7 +287,7 @@ func setHelmEnv(envs map[string]string, banzaiCli cli.Cli) (map[string]string, e
 	return envs, nil
 }
 
-// TODO remove after deprecation
+// TODO remove after helm2 eol
 func setHelm2Env(envs map[string]string, banzaiCli cli.Cli) (map[string]string, error) {
 	org := banzaiCli.Context().OrganizationID()
 	helmHome := filepath.Join(banzaiCli.Home(), fmt.Sprintf("helm/org-%d", org))

--- a/internal/cli/command/cluster/helm.go
+++ b/internal/cli/command/cluster/helm.go
@@ -140,6 +140,7 @@ func runHelm(banzaiCli cli.Cli, options helmOptions, args []string) error {
 		} else {
 			if tiller, _ := tillerVersion(); tiller != "" {
 				log.Warn("Helm version 2 is deprecated but tiller is found on the cluster. Please migrate to helm version 3.")
+				log.Warn("Until the migration, you can use the 'helm2' command instead of 'helm'.")
 			}
 			envs, err = setHelmEnv(envs, banzaiCli)
 			if err != nil {

--- a/internal/cli/command/cluster/shell.go
+++ b/internal/cli/command/cluster/shell.go
@@ -290,7 +290,7 @@ exec %s cluster _helm -- "$@"
 		if err := ioutil.WriteFile(filepath.Join(bindir, "helm"), []byte(script), 0755); err != nil {
 			return errors.WrapIf(err, "failed to write helm wrapper script")
 		}
-
+		// TODO remove after helm2 eol
 		script = fmt.Sprintf(`#!/bin/sh
 exec %s cluster _helm -v 2 -- "$@"
 `, cmd)

--- a/internal/cli/command/cluster/shell.go
+++ b/internal/cli/command/cluster/shell.go
@@ -290,6 +290,14 @@ exec %s cluster _helm -- "$@"
 		if err := ioutil.WriteFile(filepath.Join(bindir, "helm"), []byte(script), 0755); err != nil {
 			return errors.WrapIf(err, "failed to write helm wrapper script")
 		}
+
+		script = fmt.Sprintf(`#!/bin/sh
+exec %s cluster _helm -v 2 -- "$@"
+`, cmd)
+
+		if err := ioutil.WriteFile(filepath.Join(bindir, "helm2"), []byte(script), 0755); err != nil {
+			return errors.WrapIf(err, "failed to write helm2 wrapper script")
+		}
 	}
 
 	log.Debugf("Environment: %v", envs)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
This PR contains implementations of the helm 3 support.
- `helm` command calls the helm version 3 (helm version gets from Pipeline API)
- `helm2` command calls the helm version 2 (helm version gets from tiller)
- in case of helm 3 is supported by Pipeline and tiller is still on the cluster, a warning message will appear.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
