### PR TITLE
Make sure to use the generated SSH key

### DIFF
--- a/internal/cli/command/controlplane/ec2.go
+++ b/internal/cli/command/controlplane/ec2.go
@@ -47,7 +47,7 @@ func ensureEC2Cluster(options *cpContext, creds map[string]string, useGeneratedK
 
 	argv := []string{"-oStrictHostKeyChecking=no", "-l", "centos"}
 	if useGeneratedKey {
-		argv = append(argv, "-i", options.sshkeyPath(), "-F", "/dev/null")
+		argv = append(argv, "-oIdentitiesOnly=yes", "-i", options.sshkeyPath(), "-F", "/dev/null")
 	}
 
 	argv = append(argv, host, "sudo", "cat", "/etc/kubernetes/admin.conf")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR fixes EC2 SSH auth when the SSH agent already has a large number of keys in it.


### Why?
When using a generated keypair, make sure to only use it, otherwise the user might run into `Too many authentication failures` errors.
