### PR TITLE
Fix version detection when helm3 is not yet enabled

### DIFF
--- a/internal/cli/command/cluster/helm.go
+++ b/internal/cli/command/cluster/helm.go
@@ -241,7 +241,13 @@ func getHelmVersion(banzaiCli cli.Cli) (string, error) {
 		return "", errors.WrapIf(err, "failed to retrieve capabilities")
 	}
 
-	return fmt.Sprintf("v%s", caps["helm"]["version"]), nil
+	if helm, ok := caps["helm"]; ok {
+		if version, ok := helm["version"]; ok {
+			return fmt.Sprintf("v%s", version), nil
+		}
+	}
+
+	return "", nil
 }
 
 func getHelmBinary(version string, banzaiCli cli.Cli) (string, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix helm version detection with older pipeline versions, or newer versions where helm3 is disabled.


### Why?
Currently the version is detected as `v%!s(<nil>)` due to trying to fill a non existent field as a version string.

