### PR TITLE
process-log: don't hit the API hard when polling

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -119,5 +119,7 @@ func TailProcess(banzaiCli cli.Cli, processId string) error {
 		} else if process.Status != pipeline.RUNNING {
 			return ProcessFailedError{fmt.Sprintf("%s process %s: %s", process.Type, process.Status, process.Log)}
 		}
+
+		time.Sleep(2 * time.Second)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Don't hit the API hard when polling the process log.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
