### PR TITLE
Kubeconfig path management updates

### DIFF
--- a/internal/cli/command/controlplane/exec.go
+++ b/internal/cli/command/controlplane/exec.go
@@ -43,7 +43,7 @@ func runTerraform(command string, options *cpContext, env map[string]string, tar
 		return errors.WrapIf(err, "failed to pull cp-installer")
 	}
 
-	cmdEnv := map[string]string{"KUBECONFIG": "/workspace/" + kubeconfigFilename}
+	cmdEnv := map[string]string{}
 	for k, v := range env {
 		cmdEnv[k] = v
 	}

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -176,6 +176,13 @@ func (c *cpContext) deleteTfstate() error {
 func (c *cpContext) writeKubeconfig(outBytes []byte) error {
 	path := c.kubeconfigPath()
 	log.Debugf("writing kubeconfig file to %q", path)
+	if ok, err := dirExists(filepath.Dir(path)); err != nil {
+		return err
+	} else if !ok {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return errors.WrapIf(err, "failed to create directories for kubeconfig")
+		}
+	}
 	return errors.WrapIf(ioutil.WriteFile(path, outBytes, 0600), "failed to write kubeconfig file")
 }
 

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -151,9 +151,12 @@ func (c *cpContext) kubeconfigPath() string {
 	return filepath.Join(c.workspace, ".kube", "config")
 }
 
+func (c *cpContext) legacyKubeconfigPath() string {
+	return filepath.Join(c.workspace, "kubeconfig")
+}
+
 func (c *cpContext) kubeconfigExists() bool {
-	_, err := os.Stat(c.kubeconfigPath())
-	return err == nil
+	return fileExists(c.kubeconfigPath()) || fileExists(c.legacyKubeconfigPath())
 }
 
 func (c *cpContext) tfstatePath() string {

--- a/internal/cli/command/controlplane/installer_options.go
+++ b/internal/cli/command/controlplane/installer_options.go
@@ -34,7 +34,6 @@ import (
 const (
 	workspaceKey            = "installer.workspace"
 	valuesFilename          = "values.yaml"
-	kubeconfigFilename      = "kubeconfig"
 	ec2HostFilename         = "ec2-host"
 	sshkeyFilename          = "id_rsa"
 	traefikAddressFilename  = "traefik-address"
@@ -149,7 +148,7 @@ func (c *cpContext) readValues(out interface{}) error {
 }
 
 func (c *cpContext) kubeconfigPath() string {
-	return filepath.Join(c.workspace, kubeconfigFilename)
+	return filepath.Join(c.workspace, ".kube", "config")
 }
 
 func (c *cpContext) kubeconfigExists() bool {
@@ -181,7 +180,10 @@ func (c *cpContext) writeKubeconfig(outBytes []byte) error {
 }
 
 func (c *cpContext) deleteKubeconfig() error {
-	return os.Remove(c.kubeconfigPath())
+	if c.kubeconfigExists() {
+		return os.Remove(c.kubeconfigPath())
+	}
+	return nil
 }
 
 func (c *cpContext) sshkeyPath() string {

--- a/internal/cli/command/controlplane/utils.go
+++ b/internal/cli/command/controlplane/utils.go
@@ -39,6 +39,17 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
+func dirExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if info.IsDir() {
+		return true, nil
+	}
+	return false, errors.New("file exists but not a directory")
+}
+
 type ExportedFilesHandler func(map[string][]byte) error
 
 func processExports(options *cpContext, source string, exportedFilesHandlers []ExportedFilesHandler) error {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Avoid setting the KUBECONFIG env var for terraform commands as the installer image already contains the path where it expects it's kubeconfig. 

The latest installer image will require the updated banzai-cli to find its kubeconfig at the right location.

Existing deployments above installer version 0.4.1 (inclusive) should still be upgradeable and destroyable with the latest image as well since their image has the KUBECONFIG=/workspace/kubeconfig environment variable baked in.
