### PR TITLE
scan: add registry configurability support

### DIFF
--- a/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
+++ b/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
@@ -38,6 +38,7 @@ type ServiceSpec struct {
 	Policy           policySpec        `json:"policy" mapstructure:"policy"`
 	ReleaseWhiteList []releaseSpec     `json:"releaseWhiteList,omitempty" mapstructure:"releaseWhiteList"`
 	WebhookConfig    webHookConfigSpec `json:"webhookConfig" mapstructure:"webhookConfig"`
+	Registry         *registrySpec     `json:"registry,omitempty" mapstructure:"registry"`
 }
 
 // Validate validates the input security scan specification.
@@ -57,6 +58,10 @@ func (s ServiceSpec) Validate() error {
 	}
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate())
+
+	if s.Registry != nil {
+		validationErrors = errors.Combine(validationErrors, s.Registry.Validate())
+	}
 
 	return validationErrors
 }
@@ -112,6 +117,21 @@ func (w webHookConfigSpec) Validate() error {
 		if w.Selector == "" || len(w.Namespaces) < 1 {
 			return errors.NewPlain("selector and namespaces must be filled")
 		}
+	}
+
+	return nil
+}
+
+type registrySpec struct {
+	Type     string `json:"type" mapstructure:"type"`
+	Registry string `json:"registry" mapstructure:"registry"`
+	SecretID string `json:"secretId" mapstructure:"secretId"`
+	Insecure bool   `json:"insecure" mapstructure:"insecure"`
+}
+
+func (s registrySpec) Validate() error {
+	if s.Registry == "" || s.SecretID == "" {
+		return errors.New("both registry and secretId are required")
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Allow specifying a custom registry in the security scan enablement command.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
