### PR TITLE
fix using generated ssh key in case of ec2 provider

### DIFF
--- a/internal/cli/command/controlplane/up.go
+++ b/internal/cli/command/controlplane/up.go
@@ -161,10 +161,11 @@ func runUp(options *createOptions, banzaiCli cli.Cli) error {
 		useGeneratedKey := true
 		if pc, ok := values["providerConfig"]; ok {
 			if pc, ok := pc.(map[interface{}]interface{}); ok {
-				useGeneratedKey = pc["key_name"] != nil && pc["key_name"] != ""
+				if pc["key_name"] != nil && pc["key_name"] != "" {
+					useGeneratedKey = false
+				}
 			}
 		}
-
 		if err := ensureEC2Cluster(options.cpContext, env, useGeneratedKey); err != nil {
 			return errors.WrapIf(err, "failed to create EC2 cluster")
 		}


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fix the setup of the useGeneratedKey variable.

The error occurred due to the false value of the useGeneratedKey.
```retrieve kubernetes config from cluster "ec2-54-185-225-73.us-west-2.compute.amazonaws.com"
INFO[0029] ssh -oStrictHostKeyChecking=no -l centos ec2-54-185-225-73.us-west-2.compute.amazonaws.com sudo cat /etc/kubernetes/admin.conf
centos@ec2-54-185-225-73.us-west-2.compute.amazonaws.com: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
failed to create EC2 cluster: failed to retrieve kubernetes config from cluster: exit status 255