### PR TITLE
sts: increase session duration to 1 hour

### DIFF
--- a/internal/cli/input/secret.go
+++ b/internal/cli/input/secret.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/AlecAivazis/survey/v2"
@@ -96,7 +97,10 @@ func GetAmazonCredentials(profile string, assumeRole string) (string, map[string
 	var creds credentials.Value
 
 	if assumeRole != "" {
-		creds, err = stscreds.NewCredentials(session, assumeRole).Get()
+		options := func(p *stscreds.AssumeRoleProvider) {
+			p.Duration = 1 * time.Hour
+		}
+		creds, err = stscreds.NewCredentials(session, assumeRole, options).Get()
 		if err != nil {
 			return "", nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Increasing the STS session duration to 1 hour, which is the AWS account default globally.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To have longer sessions compared to the default 15 minutes.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
