### PR TITLE
chore(git): ignore generated local documentation files at cmd/docs/*.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # packr files https://github.com/gobuffalo/packr/tree/master/v2
 *-packr.go
 
+# banzai cli generated local documentation files
+/cmd/docs/*.md
+
 # pipeline openapi files
 /pipeline-openapi.yaml
 /.gen/pipeline/.travis.yml


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR added cmd/docs/*.md files to the repository level .gitignore file to be ignored.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It is convenient to hide these files from the git file changes as feature development usually requires adjusting the documentation as well, which can be easily verified with the generated local documentation.
These documentation files are also changing dynamically which would require extra efforts to be kept in sync on the repository remote thus committing them would not be feasible.

This practice might be opinionated, so feel free to engage in a discussion about whether the content of this PR would be a useful addition.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
