### PR TITLE
shell: quit when nesting banzai cluster shell

### DIFF
--- a/internal/cli/command/cluster/shell.go
+++ b/internal/cli/command/cluster/shell.go
@@ -117,6 +117,10 @@ func runShell(banzaiCli cli.Cli, options shellOptions, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if os.Getenv("BANZAI_CURRENT_CLUSTER_ID") != "" {
+		return errors.New("banzai cluster shell sessions should be nested with care, exit or unset $BANZAI_CURRENT_CLUSTER_ID to force")
+	}
+
 	pipeline := banzaiCli.Client()
 	orgId := banzaiCli.Context().OrganizationID()
 	if err := options.Init(); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Exit with error message when `banzai cluster shell` is run within another session.

### Why?
It's almost always confusing and never useful to nest such sessions.