### PR TITLE
Make the installer work with AWS_PROFILE set as an environment variable (warn if overrides config file setting).

### DIFF
--- a/internal/cli/command/controlplane/utils.go
+++ b/internal/cli/command/controlplane/utils.go
@@ -165,12 +165,18 @@ func getImageMetadata(cpContext *cpContext, values map[string]interface{}, write
 
 	awsAccessKeyID := ""
 	if values["provider"] == providerEc2 || imageMeta.Custom.CredentialType == "aws" {
-		profile := "default"
+		profile := ""
 		assumeRole := ""
 		if v, ok := values["providerConfig"]; ok {
 			providerConfig := cast.ToStringMap(v)
 			profile = cast.ToString(providerConfig["profile"])
 			assumeRole = cast.ToString(providerConfig["assume_role"])
+		}
+		if envProfile, ok := os.LookupEnv("AWS_PROFILE"); ok {
+			if profile != "" {
+				log.Warnf("AWS profile `%s` in the providerConfig is overridden to `%s` by AWS_PROFILE env var explicitly", profile, envProfile)
+			}
+			profile = envProfile
 		}
 		log.Debug("using local AWS credentials")
 		id, creds, err := input.GetAmazonCredentials(profile, assumeRole)

--- a/internal/cli/input/secret.go
+++ b/internal/cli/input/secret.go
@@ -96,7 +96,7 @@ func GetAmazonCredentials(profile string, assumeRole string) (string, map[string
 	// use direct auth based on exported env vars
 	if id, ok := os.LookupEnv("AWS_ACCESS_KEY_ID"); ok {
 		if profile != "" {
-			log.Warnf("AWS profile %s is overridden by access key id %s explicitly", profile, id)
+			log.Warnf("AWS profile `%s` is overridden to `%s` by AWS_ACCESS_KEY_ID env var explicitly", profile, id)
 		}
 		sess, err = session.NewSession(&aws.Config{})
 	} else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Fixes | #265  |
| License         | Apache 2.0


### What's in this PR?
Enables the use of the AWS_PROFILE env variable in case of a custom AWS provider where otherwise a profile is set in the config file. Warn in case if it has to be overridden.

### Why?
Without an env var the config cannot be overridden to a custom profile, if the user has it under a different name for example.
