### PR TITLE
fix slice allocation in GetCurlCommand

### DIFF
--- a/internal/cli/utils/http2curl.go
+++ b/internal/cli/utils/http2curl.go
@@ -54,7 +54,7 @@ func GetCurlCommand(req *http.Request, insecureSkipVerify bool) (*CurlCommand, e
 
 	command.append("-X", bashEscape(req.Method))
 
-	keys := make([]string, len(req.Header))
+	keys := make([]string, 0, len(req.Header))
 	for k := range req.Header {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The header slice was preallocated in `GetCurlCommand` and prefilled with empty values, but it should be only preallocated.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
```
DEBU[0000] curl -k -X 'GET' -H ': ' -H ': ' -H ': ' -H 'Accept: application/json'

vs.

DEBU[0000] curl -k -X 'GET' -H 'Accept: application/json'
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
