### PR TITLE
feat(cl/np/delete): added response-based info msg

### DIFF
--- a/internal/cli/command/cluster/nodepool/delete.go
+++ b/internal/cli/command/cluster/nodepool/delete.go
@@ -16,6 +16,8 @@ package nodepool
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/banzai-cli/internal/cli"
@@ -80,6 +82,13 @@ func deleteNodePool(banzaiCli cli.Cli, options deleteOptions, args []string) err
 		cli.LogAPIError("delete node pool", err, nodePoolName)
 
 		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		_, _ = fmt.Fprintf(banzaiCli.Out(), "delete process initiated for node pool '%s'\n", nodePoolName)
+	case http.StatusNoContent:
+		_, _ = fmt.Fprintf(banzaiCli.Out(), "node pool '%s' does not exist, nothing to do\n", nodePoolName)
 	}
 
 	return nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes (command output)
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #288 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added a success describing informational message to `banzai cluster nodepool delete` based on the response status.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Success codes can come from two statuses a, `202 Accepted` deletion initiated and b, `204 No Content` node pool not found and if the user doesn't notice a typo in the node pool name a silent success may shadow issues and generate cost by not deleting the node pool. With such an informational message it is immediately determinable whether the deletion was successfully initiated.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

#### Test matrix

```yaml
nodePool:
    - does not exist
    - exists
```

<details>
  <summary>Node pool does not exist</summary>

```shell
> ./build/banzai cluster nodepool list

? Cluster: pregnor-3161-valid-volume-size-cluster-create
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice
pool1  1     Enabled      1            2            20          t2.small      ami-065ebfccbbb1c5734  0.01     
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01     

> ./build/banzai cluster nodepool delete pool3 --cluster-name pregnor-3161-valid-volume-size-cluster-create

node pool 'pool3' does not exist, nothing to do

> ./build/banzai cluster nodepool list

? Cluster: pregnor-3161-valid-volume-size-cluster-create
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice
pool1  1     Enabled      1            2            20          t2.small      ami-065ebfccbbb1c5734  0.01     
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01  
```
</details>

<details>
  <summary>Node pool exists</summary>

```shell
> ./build/banzai cluster nodepool list

? Cluster: pregnor-3161-valid-volume-size-cluster-create
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice
pool1  1     Enabled      1            2            20          t2.small      ami-065ebfccbbb1c5734  0.01     
pool2  1     Enabled      1            2            22          t2.small      ami-065ebfccbbb1c5734  0.01     

> ./build/banzai cluster nodepool delete pool2 --cluster-name pregnor-3161-valid-volume-size-cluster-create

delete process initiated for node pool 'pool2'

> ./build/banzai cluster nodepool list

? Cluster: pregnor-3161-valid-volume-size-cluster-create
Name   Size  Autoscaling  MinimumSize  MaximumSize  VolumeSize  InstanceType  Image                  SpotPrice
pool1  1     Enabled      1            2            20          t2.small      ami-065ebfccbbb1c5734  0.01     
```
</details>

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
