### PR TITLE
fix(make): synced variables with dependency order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,19 @@ OS = $(shell uname | tr A-Z a-z)
 PACKAGE = github.com/banzaicloud/banzai-cli
 BINARY_NAME = banzai
 
+PIPELINE_VERSION = 0.57.0
+CLOUDINFO_VERSION = 0.13.0
+TELESCOPES_VERSION = 0.5.3
+
+# Dependency versions
+GOTESTSUM_VERSION = 0.4.1
+GOLANGCI_VERSION = 1.24.0
+LICENSEI_VERSION = 0.1.0
+GORELEASER_VERSION = 0.112.2
+OPENAPI_GENERATOR_VERSION = v4.2.3
+
+GOLANG_VERSION = 1.14
+
 # Build variables
 BUILD_DIR ?= build
 BUILD_PACKAGE = ${PACKAGE}/cmd/banzai
@@ -20,19 +33,6 @@ ifeq ($(filter -v,${GOARGS}),)
 endif
 TEST_FORMAT = short-verbose
 endif
-
-PIPELINE_VERSION = 0.57.0
-CLOUDINFO_VERSION = 0.13.0
-TELESCOPES_VERSION = 0.5.3
-
-# Dependency versions
-GOTESTSUM_VERSION = 0.4.1
-GOLANGCI_VERSION = 1.24.0
-LICENSEI_VERSION = 0.1.0
-GORELEASER_VERSION = 0.112.2
-OPENAPI_GENERATOR_VERSION = v4.2.3
-
-GOLANG_VERSION = 1.14
 
 # Add the ability to override some variables
 # Use with care


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #306 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Reordered the variable definitions in the Makefile to make sure versions required for the build arguments (LDFLAGS) are defined before the build arguments themselves.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Currently Pipeline version is not displayed on `banzai --version` due to the Pipeline variable being defined after the LDFLAGS value is set. This PR fixes that.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Moved all versions so it looks more consistent than just moving the Pipeline version.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
