### PR TITLE
fix(goreleaser): fixed ldflags & Pipeline version

### DIFF
--- a/.goreleaser.unstable.yml
+++ b/.goreleaser.unstable.yml
@@ -4,7 +4,7 @@ builds:
         binary: banzai
         env:
             - CGO_ENABLED=0
-        ldflags: "-s -w -X main.version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
+        ldflags: "-s -w {{ .Env.GORELEASER_LDFLAGS }}"
         goos:
             - linux
             - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
         binary: banzai
         env:
             - CGO_ENABLED=0
-        ldflags: "-s -w -X main.version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
+        ldflags: "-s -w {{ .Env.GORELEASER_LDFLAGS }}"
         goos:
             - linux
             - darwin

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ bin/goreleaser-${GORELEASER_VERSION}:
 
 .PHONY: release
 release: bin/goreleaser # Publish a release
-	bin/goreleaser release ${GORELEASERFLAGS}
+	GORELEASER_LDFLAGS="$(LDFLAGS)" bin/goreleaser release ${GORELEASERFLAGS}
 
 # release-%: TAG_PREFIX = v
 release-%:
@@ -211,7 +211,7 @@ major: ## Release a new major version
 
 .PHONY: unstable
 unstable: bin/goreleaser # Publish an experimental release
-	bin/goreleaser release -f .goreleaser.unstable.yml ${GORELEASERFLAGS}
+	GORELEASER_LDFLAGS="$(LDFLAGS)" bin/goreleaser release -f .goreleaser.unstable.yml ${GORELEASERFLAGS}
 
 .PHONY: list
 list: ## List all make targets


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #306 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the `banzai --version` output (missing Pipeline version).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The ` main.pipelineVersion` value definition was missing from the Goreleaser configuration which caused the Pipeline version to not be set in the released binary.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
 
<details>
  <summary>Solution reasoning</summary>

Tried fixing it in the Goreleaser configuration, but dynamic information is very difficult to be configured there.

Failed with 

1. env (added literally),
2. build hook (implemented by the documentation, failing the schema check),
3. global hook (not changing environment through command),

so I was pretty much up to writing a hookable script for this or resolving it by passing the dynamic information into the executing environment **before** Goreleaser is run. I decided it's easier to set a unique environment variable in the `Makefile` where the required value is (and `LDFLAGS` are) configured anyway, thus `GORELEASER_LDFLAGS` temporary environment variable was introduced to the Goreleraser Make targets.

Decided to pass the entire `LDFLAGS` instead of just `PIPELINE_VERSION` because that way code repetition and thus desynchronization caused regression can be avoided making this a less error-prone solution.

</details>

<details>
  <summary>Testing instructions</summary>

Replace the `.goreleaser.unstable.yml` file's content with the following: (release disable instruction and everyting aside from build section commented out)
```yaml
builds:
    -
        main: ./cmd/banzai
        binary: banzai
        env:
            - CGO_ENABLED=0
        ldflags: "-s -w {{ .Env.GORELEASER_LDFLAGS }}"
        goos:
            - linux
            - darwin
        goarch:
            - amd64

release:
    disable: true

# archives:
#     -
#         name_template: "banzai_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

# checksum:
#     name_template: "banzai_checksums.txt"

# changelog:
#     skip: true

# nfpms:
#     -
#         vendor: Banzai Cloud
#         maintainer: Banzai Cloud <info@banzaicloud.com>
#         homepage: https://banzaicloud.com/
#         description: Command-line interface for Banzai Cloud Pipeline platform
#         formats:
#             - deb
#             - rpm
#         bindir: /usr/bin
#         license: Apache 2.0
```

Commit your changes to a temporary commit as Goreleaser does not allow releasing from dirty state.

Then it can be tested with the following sequence of commands:

```shell
git tag 0.15.2-dev.1 -m "0.15.2-dev.1: test fixing goreleaser" \
    && rm -fr ./dist \
    && make unstable \
    && git tag -d 0.15.2-dev.1 \
    && ./dist/banzai-cli_darwin_amd64/banzai --version
```

Don't forget to delete the temporary commit.

</details>

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~