### PR TITLE
fix(cl/np/list): added subnet ID

### DIFF
--- a/internal/cli/command/cluster/nodepool/list.go
+++ b/internal/cli/command/cluster/nodepool/list.go
@@ -51,6 +51,7 @@ type nodePoolListItem struct {
 	InstanceType string
 	Image        string
 	SpotPrice    string
+	SubnetID     string
 }
 
 type nodePoolListOptions struct {
@@ -103,6 +104,7 @@ func runNodePoolList(banzaiCli cli.Cli, options nodePoolListOptions) error {
 			InstanceType: nodePool.InstanceType,
 			Image:        nodePool.Image,
 			SpotPrice:    nodePool.SpotPrice,
+			SubnetID:     nodePool.SubnetId,
 		}
 	}
 

--- a/internal/cli/format/node_pools.go
+++ b/internal/cli/format/node_pools.go
@@ -25,7 +25,7 @@ func NodePoolsWrite(context formatContext, data interface{}) {
 		Out:    context.Out(),
 		Color:  context.Color(),
 		Format: context.OutputFormat(),
-		Fields: []string{"Name", "Size", "Autoscaling", "MinimumSize", "MaximumSize", "VolumeSize", "InstanceType", "Image", "SpotPrice"},
+		Fields: []string{"Name", "Size", "Autoscaling", "MinimumSize", "MaximumSize", "VolumeSize", "InstanceType", "Image", "SpotPrice", "SubnetID"},
 	}
 
 	err := output.Output(ctx, data)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added subnet ID to `banzai cluster nodepool list` output.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It is an argument specified at node pool creation which should be returned on node pool list, previously it was missing from the API output.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Documentation [PR](https://github.com/banzaicloud/banzaicloud.github.io/pull/1839).
Pipeline [PR](https://github.com/banzaicloud/pipeline/pull/3180).

Tested with old API, works fine with empty value.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] Documentation PR.
