### PR TITLE
login: remove old user_sess cookie support

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -20,6 +20,7 @@ ignored = [
     # Vanity URLS :\
     "cloud.google.com/go",
     "emperror.dev/errors",
+    "gopkg.in/square/go-jose.v2",
     "go.opencensus.io",
     "go.uber.org/atomic",
     "go.uber.org/multierr",

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -189,13 +189,6 @@ func (a *LoginApp) requestTokenFromPipeline(rawIDToken string, refreshToken stri
 		return "", fmt.Errorf("request returned: %s", string(body))
 	}
 
-	// The old version of getting the Pipeline token, should be removed in a future release.
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "user_sess" {
-			return cookie.Value, nil
-		}
-	}
-
 	sessionToken := resp.Header.Get("Authorization")
 	if sessionToken != "" {
 		return sessionToken, nil


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Removing the presence check fo the user_sess cookie, which is not sent by Pipeline a long ago.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
