### PR TITLE
backup: set cluster.cloud in options in every case

### DIFF
--- a/internal/cli/command/cluster/context/context.go
+++ b/internal/cli/command/cluster/context/context.go
@@ -90,6 +90,7 @@ func (c *clusterContext) Init(args ...string) error {
 		}
 
 		c.name = cluster.Name
+		c.cloud = cluster.Cloud
 
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #280 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Set cluster cloud even if cluster.id is defined in options. This was missing.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise, the `"Deploy cluster secret to give access for Velero to make volume snapshots"` feature in the backup service won't work.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
