### PR TITLE
backup: implement restore-id handling

### DIFF
--- a/internal/cli/command/cluster/restore/create.go
+++ b/internal/cli/command/cluster/restore/create.go
@@ -83,7 +83,7 @@ func runCreate(banzaiCli cli.Cli, options createOptions) error {
 		return errors.WrapIfWithDetails(err, "failed to create restore", "clusterID", clusterID, "backupName", options.backupName)
 	}
 
-	log.Infof("Starting to restore cluster. You can check the status with `banzai cluster restore result --restoreId=%d`", response.Restore.Id)
+	log.Infof("Starting to restore cluster. You can check the status with `banzai cluster restore result --restore-id=%d`", response.Restore.Id)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #271 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add restore-id handling to the `banzai cluster restore result` subcommand.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It was suggested it exists, but it didn't.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
