### PR TITLE
feat(securityscan): add multiple registries

### DIFF
--- a/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
+++ b/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
@@ -59,10 +59,8 @@ func (s ServiceSpec) Validate() error {
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate())
 
-	if s.Registries != nil {
-		for _, registryItem := range s.Registries {
-			validationErrors = errors.Combine(validationErrors, registryItem.Validate())
-		}
+	for _, registryItem := range s.Registries {
+		validationErrors = errors.Combine(validationErrors, registryItem.Validate())
 	}
 
 	return validationErrors

--- a/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
+++ b/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
@@ -38,7 +38,8 @@ type ServiceSpec struct {
 	Policy           policySpec        `json:"policy" mapstructure:"policy"`
 	ReleaseWhiteList []releaseSpec     `json:"releaseWhiteList,omitempty" mapstructure:"releaseWhiteList"`
 	WebhookConfig    webHookConfigSpec `json:"webhookConfig" mapstructure:"webhookConfig"`
-	Registries       []*registrySpec   `json:"registry,omitempty" mapstructure:"registries"`
+	Registry         *registrySpec     `json:"registry,omitempty" mapstructure:"registry"`
+	Registries       []*registrySpec   `json:"registries,omitempty" mapstructure:"registries"`
 }
 
 // Validate validates the input security scan specification.
@@ -58,6 +59,10 @@ func (s ServiceSpec) Validate() error {
 	}
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate())
+
+	if s.Registry != nil {
+		validationErrors = errors.Combine(validationErrors, s.Registry.Validate())
+	}
 
 	for _, registryItem := range s.Registries {
 		validationErrors = errors.Combine(validationErrors, registryItem.Validate())

--- a/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
+++ b/internal/cli/command/cluster/integratedservice/services/securityscan/common.go
@@ -38,7 +38,7 @@ type ServiceSpec struct {
 	Policy           policySpec        `json:"policy" mapstructure:"policy"`
 	ReleaseWhiteList []releaseSpec     `json:"releaseWhiteList,omitempty" mapstructure:"releaseWhiteList"`
 	WebhookConfig    webHookConfigSpec `json:"webhookConfig" mapstructure:"webhookConfig"`
-	Registry         *registrySpec     `json:"registry,omitempty" mapstructure:"registry"`
+	Registries       []*registrySpec   `json:"registry,omitempty" mapstructure:"registries"`
 }
 
 // Validate validates the input security scan specification.
@@ -59,8 +59,10 @@ func (s ServiceSpec) Validate() error {
 
 	validationErrors = errors.Combine(validationErrors, s.WebhookConfig.Validate())
 
-	if s.Registry != nil {
-		validationErrors = errors.Combine(validationErrors, s.Registry.Validate())
+	if s.Registries != nil {
+		for _, registryItem := range s.Registries {
+			validationErrors = errors.Combine(validationErrors, registryItem.Validate())
+		}
 	}
 
 	return validationErrors


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related https://github.com/banzaicloud/pipeline/pull/3403
| License         | Apache 2.0

### What's in this PR?
Implement supporting multiple image registries in `securityscan` integrated service.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

