### PR TITLE
Fixed GoReleaser install in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,12 @@ generate-telescopes-client: ## Generate client from Telescopes OpenAPI spec
 
 bin/goreleaser: bin/goreleaser-${GORELEASER_VERSION}
 	@ln -sf goreleaser-${GORELEASER_VERSION} bin/goreleaser
+
+# Note: removing the last line of the script because we install and run
+# goreleaser in 2 separate steps, the last line is the execution line.
 bin/goreleaser-${GORELEASER_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | bash -s -- -b ./bin/ v${GORELEASER_VERSION}
+	curl -sfL https://git.io/goreleaser | sed '$$ d' | TMPDIR=./bin VERSION=v${GORELEASER_VERSION} bash
 	@mv bin/goreleaser $@
 
 .PHONY: release


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed GoReleaser install in the build.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Broke on CI when releasing a new stable version.
https://app.circleci.com/pipelines/github/banzaicloud/banzai-cli/1501/workflows/f1c04f5d-a262-480d-bbed-423e6a177c0e/jobs/2652

Fixed by replacing the deprecated GoReleaser install script.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
