### PR TITLE
fix: split cluster delete log to different levels

### DIFF
--- a/internal/cli/command/cluster/delete.go
+++ b/internal/cli/command/cluster/delete.go
@@ -74,11 +74,12 @@ func runDelete(banzaiCli cli.Cli, options deleteOptions, args []string) error {
 			return errors.New("deletion cancelled")
 		}
 	}
-	if cluster, err := client.ClustersApi.DeleteCluster(context.Background(), orgId, id, &pipeline.DeleteClusterOpts{Force: optional.NewBool(options.force)}); err != nil {
+	if resp, err := client.ClustersApi.DeleteCluster(context.Background(), orgId, id, &pipeline.DeleteClusterOpts{Force: optional.NewBool(options.force)}); err != nil {
 		cli.LogAPIError("delete cluster", err, id)
 		return errors.WrapIf(err, "failed to delete cluster")
 	} else {
-		log.Printf("Deleting cluster %v", cluster)
+		log.Info("deleting cluster")
+		log.Debug(resp)
 	}
 	if cluster, _, err := client.ClustersApi.GetCluster(context.Background(), orgId, id); err != nil {
 		cli.LogAPIError("get cluster", err, id)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This change affects the log after a successful cluster delete:
- set the log level of the http response to debug
- set the log level of the action info message to info
- decapitalize the action info message to match the style of similar logs
- change misleading variable name holding the http response object

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It is unnecessary to log the response from the api when deleting a cluster, but can be useful when debugging.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

#### Before

```
? Do you want to DELETE the cluster? Yes
INFO[0009] Deleting cluster &{202 Accepted 202 HTTP/1.1 1 1 map[Content-Length:[0] Date:[Wed, 03 Nov 2021 14:43:06 GMT]] 0xc0003fa600 0 [] false false map[] 0xc0000be900 0xc0000f0000} 
```

#### After

```
? Do you want to DELETE the cluster? Yes
INFO[0009] deleting cluster 
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~
