### PR TITLE
Handle double create 201 response

### DIFF
--- a/internal/cli/command/cluster/create.go
+++ b/internal/cli/command/cluster/create.go
@@ -108,10 +108,15 @@ func runCreate(banzaiCli cli.Cli, options createOptions) error {
 	}
 
 	log.Debugf("create request: %#v", out)
-	cluster, _, err := banzaiCli.Client().ClustersApi.CreateCluster(context.Background(), orgID, out)
+	cluster, resp, err := banzaiCli.Client().ClustersApi.CreateCluster(context.Background(), orgID, out)
 	if err != nil {
 		cli.LogAPIError("create cluster", err, out)
 		return errors.WrapIf(err, "failed to create cluster")
+	}
+
+	if resp.StatusCode == http.StatusCreated {
+		log.Infof(`cluster "%s" is already being created`, out["name"])
+		return nil
 	}
 
 	log.Info("cluster is being created")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related PRs | https://github.com/banzaicloud/pipeline/pull/3587
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Return a `cluster XYZ is already being created` message if the response code of cluster create is 201 Created.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

If the cluster creation is called with the wait flag (`-w`) on the same cluster name repeatedly, it floods the terminal with an error message because in this case a cluster object is not returned that could be watched, so the function needs to return before that would happen.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~[] User guide and development docs updated (if needed)~
- ~[] Related Helm chart(s) updated (if needed)~