### PR TITLE
Fix authentication apiversion in kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/pkg/kubectlversion/kubectlversion.go
+++ b/pkg/kubectlversion/kubectlversion.go
@@ -1,0 +1,65 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubectlversion
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	"emperror.dev/errors"
+	"github.com/Masterminds/semver"
+)
+
+type clientVersion struct {
+	GitVersion string `json:"gitVersion,omitempty"`
+}
+
+type kubectlVersionOutput struct {
+	ClientVersion clientVersion `json:"clientVersion,omitempty"`
+}
+
+func getLocalKubectlVersion() (clientVersion, error) {
+	c := exec.Command("kubectl", "version", "--client=true", "-o", "json")
+	out, err := c.Output()
+	if err != nil {
+		return clientVersion{}, errors.WrapIf(err, "failed to determine kubectl version")
+	}
+
+	var parsed kubectlVersionOutput
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return clientVersion{}, errors.WrapIf(err, "failed to parse kubectl version")
+	}
+
+	return parsed.ClientVersion, nil
+}
+
+func LessThan(v string) (bool, error) {
+	inputVersion, err := semver.NewVersion(v)
+	if err != nil {
+		return false, errors.WrapIf(err, "failed to parse kubectl input version")
+	}
+
+	localKubectlVersion, err := getLocalKubectlVersion()
+	if err != nil {
+		return false, errors.WrapIf(err, "failed to get local kubectl version")
+	}
+
+	localVersion, err := semver.NewVersion(localKubectlVersion.GitVersion)
+	if err != nil {
+		return false, errors.WrapIf(err, "failed to parse kubectl local semantic version")
+	}
+
+	return localVersion.LessThan(inputVersion), nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Update apiVersion `client.authentication.k8s.io/v1alpha1` -> `client.authentication.k8s.io/v1beta1` on machines having kubectl 1.24 and greater installed in the kubeconfig returned by the command `banzai cluster shell`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In kubectl version 1.24 `client.authentication.k8s.io/v1alpha1` has been deprecated, so on machines that have the latest kubectl version installed this apiVersion needs to be updated.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Temporary fix until Pipeline itself returns the kubeconfig with the updated apiVersion.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~